### PR TITLE
fix: make remove target resolution unambiguous

### DIFF
--- a/src/commands/remove.test.ts
+++ b/src/commands/remove.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { resolveRemovalTarget } from "./remove.js";
+import type { WorktreeInfo } from "../types/index.js";
+
+const worktrees: WorktreeInfo[] = [
+  {
+    id: "abc",
+    fullId: "repo-abc",
+    path: "/tmp/wt/repo-abc",
+    branch: "feature/one",
+    repoName: "repo",
+    createdAt: "2026-03-14T00:00:00.000Z",
+  },
+  {
+    id: "abcd",
+    fullId: "repo-abcd",
+    path: "/tmp/wt/repo-abcd",
+    branch: "feature/two",
+    repoName: "repo",
+    createdAt: "2026-03-14T00:00:00.000Z",
+  },
+];
+
+describe("resolveRemovalTarget", () => {
+  test("matches exact identifiers before partial path matches", () => {
+    const result = resolveRemovalTarget(worktrees, "abc");
+
+    expect(result.worktree?.id).toBe("abc");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("allows a unique partial path match", () => {
+    const result = resolveRemovalTarget(worktrees, "repo-abcd");
+
+    expect(result.worktree?.id).toBe("abcd");
+  });
+
+  test("fails when a partial path is ambiguous", () => {
+    const result = resolveRemovalTarget(worktrees, "bc");
+
+    expect(result.worktree).toBeUndefined();
+    expect(result.error).toContain('Ambiguous worktree target "bc"');
+    expect(result.error).toContain("/tmp/wt/repo-abc");
+    expect(result.error).toContain("/tmp/wt/repo-abcd");
+  });
+
+  test("returns a not-found error when nothing matches", () => {
+    const result = resolveRemovalTarget(worktrees, "missing");
+
+    expect(result.worktree).toBeUndefined();
+    expect(result.error).toBe('Worktree with ID "missing" not found');
+  });
+});

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -1,8 +1,47 @@
 import chalk from "chalk";
 import { isGitRepository, listWorktrees, removeWorktree, deleteBranch } from "../utils/git.js";
+import type { WorktreeInfo } from "../types/index.js";
 
 interface RemoveCommandOptions {
   keepBranch?: boolean;
+}
+
+interface ResolveRemovalTargetResult {
+  worktree?: WorktreeInfo;
+  error?: string;
+}
+
+export function resolveRemovalTarget(
+  worktrees: WorktreeInfo[],
+  target: string
+): ResolveRemovalTargetResult {
+  const exactMatch = worktrees.find(
+    (wt) => wt.id === target || wt.fullId === target || wt.path === target
+  );
+
+  if (exactMatch) {
+    return { worktree: exactMatch };
+  }
+
+  const partialMatches = worktrees.filter((wt) => wt.path.includes(target));
+
+  if (partialMatches.length === 1) {
+    return { worktree: partialMatches[0] };
+  }
+
+  if (partialMatches.length > 1) {
+    const candidates = partialMatches
+      .map((wt) => `${wt.id} (${wt.path})`)
+      .join(", ");
+
+    return {
+      error: `Ambiguous worktree target "${target}". Matches: ${candidates}`,
+    };
+  }
+
+  return {
+    error: `Worktree with ID "${target}" not found`,
+  };
 }
 
 export async function removeCommand(id: string, options: RemoveCommandOptions): Promise<void> {
@@ -12,12 +51,14 @@ export async function removeCommand(id: string, options: RemoveCommandOptions): 
   }
 
   const worktrees = await listWorktrees();
-  const worktree = worktrees.find((wt) => wt.id === id || wt.fullId === id || wt.path.includes(id));
+  const result = resolveRemovalTarget(worktrees, id);
 
-  if (!worktree) {
-    console.error(chalk.red(`Error: Worktree with ID "${id}" not found`));
+  if (!result.worktree) {
+    console.error(chalk.red(`Error: ${result.error}`));
     process.exit(1);
   }
+
+  const worktree = result.worktree;
 
   try {
     console.log(chalk.blue(`Removing worktree: ${worktree.branch} (${worktree.id})...`));


### PR DESCRIPTION
## Summary
- resolve removal targets by exact identifier before any fuzzy matching
- reject ambiguous partial path matches instead of deleting the first match
- add unit coverage for exact, unique partial, ambiguous, and missing targets

## Testing
- bun test
- bun run build