### PR TITLE
fix: clean up worktrees after push failures

### DIFF
--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { $ } from "bun";
+import { branchExists, createWorktree } from "./git.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function initRepo(repoRoot: string): Promise<void> {
+  await $`git init -b main ${repoRoot}`.quiet();
+  await $`git -C ${repoRoot} config user.email test@example.com`.quiet();
+  await $`git -C ${repoRoot} config user.name tester`.quiet();
+  await Bun.write(join(repoRoot, "README.md"), "base\n");
+  await $`git -C ${repoRoot} add README.md`.quiet();
+  await $`git -C ${repoRoot} commit -m init`.quiet();
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("createWorktree", () => {
+  test("removes the new worktree and branch when push fails", async () => {
+    const previousCwd = process.cwd();
+    const repoRoot = makeTempDir("wt-git-test-");
+    const worktreeRoot = makeTempDir("wt-git-test-worktrees-");
+    const worktreePath = join(worktreeRoot, "repo-feature-fail");
+
+    await initRepo(repoRoot);
+    process.chdir(repoRoot);
+
+    try {
+      await expect(
+        createWorktree(worktreePath, "feature/push-fail", "main", true)
+      ).rejects.toThrow("git push failed with exit code 128");
+
+      expect(await Bun.file(worktreePath).exists()).toBeFalse();
+      expect(await branchExists("feature/push-fail")).toBeFalse();
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+});

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,6 +1,6 @@
 import { basename } from "path";
 import { spawn } from "bun";
-import { statSync } from "fs";
+import { existsSync, statSync } from "fs";
 import type { WorktreeInfo } from "../types/index.js";
 import { $ } from "bun";
 
@@ -52,19 +52,41 @@ export async function createWorktree(
     throw new Error(`git worktree add failed with exit code ${addResult}`);
   }
 
-  if (pushRemote) {
-    const pushProc = spawn(
-      ["git", "-C", path, "push", "-u", "origin", branch],
-      {
-        stdout: "inherit",
-        stderr: "inherit",
+  try {
+    if (pushRemote) {
+      const pushProc = spawn(
+        ["git", "-C", path, "push", "-u", "origin", branch],
+        {
+          stdout: "inherit",
+          stderr: "inherit",
+        }
+      );
+      const pushResult = await pushProc.exited;
+      if (pushResult !== 0) {
+        throw new Error(`git push failed with exit code ${pushResult}`);
       }
-    );
-    const pushResult = await pushProc.exited;
-    if (pushResult !== 0) {
-      throw new Error(`git push failed with exit code ${pushResult}`);
     }
+  } catch (error) {
+    await cleanupFailedWorktreeCreation(path, branch);
+    throw error;
   }
+}
+
+async function cleanupFailedWorktreeCreation(
+  path: string,
+  branch: string
+): Promise<void> {
+  try {
+    if (existsSync(path)) {
+      await $`git worktree remove ${path} --force`.quiet();
+    }
+  } catch {}
+
+  try {
+    if (await branchExists(branch)) {
+      await $`git branch -D ${branch}`.quiet();
+    }
+  } catch {}
 }
 
 export async function listWorktrees(): Promise<WorktreeInfo[]> {
@@ -132,6 +154,15 @@ export async function removeWorktree(path: string): Promise<void> {
 
 export async function deleteBranch(branch: string): Promise<void> {
   await $`git branch -D ${branch}`;
+}
+
+export async function branchExists(branch: string): Promise<boolean> {
+  try {
+    await $`git show-ref --verify --quiet refs/heads/${branch}`.quiet();
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export async function isBranchMergedToRemote(branch: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- clean up the linked worktree if upstream push fails during creation
- remove the newly created local branch when the worktree creation flow aborts
- add an integration test that reproduces a missing-origin push failure

## Testing
- bun test
- bun run build