### PR TITLE
fix: make shell cd handoff path-safe

### DIFF
--- a/shell/wt.bash
+++ b/shell/wt.bash
@@ -3,6 +3,7 @@
 
 wt() {
   if [ "$1" = "new" ] || [ "$1" = "cd" ]; then
+    local cd_prefix="__WT_CD__:"
     local output
     output=$(/path/to/wt "$@" 2>&1)
     local exit_code=$?
@@ -10,12 +11,13 @@ wt() {
     if [ $exit_code -eq 0 ]; then
       local last_line=$(echo "$output" | tail -n 1 | tr -d '\n')
       
-      if [[ "$last_line" == cd\ * ]]; then
+      if [[ "$last_line" == "$cd_prefix"* ]]; then
+        local target_path="${last_line#${cd_prefix}}"
         local lines=$(echo "$output" | wc -l | tr -d ' ')
         if [ "$lines" -gt 1 ]; then
           echo "$output" | sed '$d'
         fi
-        eval "$last_line"
+        builtin cd -- "$target_path"
       else
         echo "$output"
       fi

--- a/shell/wt.fish
+++ b/shell/wt.fish
@@ -3,18 +3,20 @@
 
 function wt
     if test "$argv[1]" = "new"; or test "$argv[1]" = "cd"
+        set -l cd_prefix "__WT_CD__:"
         set -l output (/path/to/wt $argv 2>&1)
         set -l exit_code $status
         
         if test $exit_code -eq 0
             set -l last_line (echo "$output" | tail -n 1 | tr -d '\n')
             
-            if string match -q "cd *" -- $last_line
+            if string match -q "$cd_prefix*" -- $last_line
+                set -l target_path (string replace "$cd_prefix" "" -- $last_line)
                 set -l lines (echo "$output" | wc -l | tr -d ' ')
                 if test $lines -gt 1
                     echo "$output" | sed '$d'
                 end
-                eval $last_line
+                cd -- "$target_path"
             else
                 echo "$output"
             end

--- a/shell/wt.zsh
+++ b/shell/wt.zsh
@@ -3,6 +3,7 @@
 
 wt() {
   if [ "$1" = "new" ] || [ "$1" = "cd" ]; then
+    local cd_prefix="__WT_CD__:"
     local output
     output=$(/path/to/wt "$@" 2>&1)
     local exit_code=$?
@@ -10,12 +11,13 @@ wt() {
     if [ $exit_code -eq 0 ]; then
       local last_line=$(echo "$output" | tail -n 1 | tr -d '\n')
       
-      if [[ "$last_line" == cd\ * ]]; then
+      if [[ "$last_line" == ${cd_prefix}* ]]; then
+        local target_path="${last_line#${cd_prefix}}"
         local lines=$(echo "$output" | wc -l | tr -d ' ')
         if [ "$lines" -gt 1 ]; then
           echo "$output" | sed '$d'
         fi
-        eval "$last_line"
+        builtin cd -- "$target_path"
       else
         echo "$output"
       fi

--- a/src/commands/cd.ts
+++ b/src/commands/cd.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import { isGitRepository, listWorktrees } from "../utils/git.js";
+import { buildCdOutput } from "../utils/cd.js";
 
 export async function cdCommand(target: string): Promise<void> {
   if (!(await isGitRepository())) {
@@ -22,5 +23,5 @@ export async function cdCommand(target: string): Promise<void> {
     process.exit(1);
   }
 
-  console.log(`cd ${worktree.path}`);
+  console.log(buildCdOutput(worktree.path));
 }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -3,8 +3,6 @@ import {
   existsSync,
   mkdirSync,
   writeFileSync,
-  readFileSync,
-  appendFileSync,
 } from "fs";
 import { join } from "path";
 import {
@@ -18,6 +16,7 @@ import {
 import { loadSettings, expandPath } from "../config/settings.js";
 import { generateShortId } from "../utils/id.js";
 import { executeScripts, executeScriptsDetached } from "../utils/script.js";
+import { buildCdOutput, formatCdCommand } from "../utils/cd.js";
 
 interface NewCommandOptions {
   base?: string;
@@ -124,10 +123,10 @@ export async function newCommand(
 
     // Output cd command for shell wrapper function
     if (options.cd !== false) {
-      console.log(`cd ${worktreePath}`);
+      console.log(buildCdOutput(worktreePath));
     } else {
       console.log(chalk.cyan(`\nTo navigate to the worktree, run:`));
-      console.log(chalk.cyan(`  cd ${worktreePath}`));
+      console.log(chalk.cyan(`  ${formatCdCommand(worktreePath)}`));
     }
   } catch (error) {
     console.error(chalk.red(`Error creating worktree: ${error}`));

--- a/src/utils/cd.test.ts
+++ b/src/utils/cd.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCdOutput,
+  CD_OUTPUT_PREFIX,
+  formatCdCommand,
+  parseCdOutput,
+  quoteShellPath,
+} from "./cd.js";
+
+describe("cd output helpers", () => {
+  test("builds and parses shell wrapper output without losing spaces", () => {
+    const path = "/tmp/wt space/repo-feature";
+    const output = buildCdOutput(path);
+
+    expect(output).toBe(`${CD_OUTPUT_PREFIX}${path}`);
+    expect(parseCdOutput(output)).toBe(path);
+  });
+
+  test("returns null for non-cd output", () => {
+    expect(parseCdOutput("cd /tmp/wt")).toBeNull();
+  });
+
+  test("quotes shell commands safely for manual copy-paste", () => {
+    const path = "/tmp/it's here/repo";
+
+    expect(quoteShellPath(path)).toBe(`'/tmp/it'"'"'s here/repo'`);
+    expect(formatCdCommand(path)).toBe(`cd '/tmp/it'"'"'s here/repo'`);
+  });
+});

--- a/src/utils/cd.ts
+++ b/src/utils/cd.ts
@@ -1,0 +1,21 @@
+export const CD_OUTPUT_PREFIX = "__WT_CD__:";
+
+export function quoteShellPath(path: string): string {
+  return `'${path.replace(/'/g, `'"'"'`)}'`;
+}
+
+export function buildCdOutput(path: string): string {
+  return `${CD_OUTPUT_PREFIX}${path}`;
+}
+
+export function parseCdOutput(line: string): string | null {
+  if (!line.startsWith(CD_OUTPUT_PREFIX)) {
+    return null;
+  }
+
+  return line.slice(CD_OUTPUT_PREFIX.length);
+}
+
+export function formatCdCommand(path: string): string {
+  return `cd ${quoteShellPath(path)}`;
+}


### PR DESCRIPTION
## Summary
- replace eval-based cd handoff with a dedicated wrapper marker
- make manual cd output shell-quoted for copy-paste safety
- add helper coverage for wrapper output parsing and quoting

## Testing
- bun test
- bun run build
- bash -n shell/wt.bash
- zsh -n shell/wt.zsh