### PR TITLE
fix: check merged status against the base branch

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -67,7 +67,7 @@ export async function listCommand(options?: {
     const createdDate = new Date(wt.createdAt);
     const timestamp = createdDate.toLocaleString();
 
-    const isMerged = await isBranchMergedToRemote(wt.branch);
+    const isMerged = await isBranchMergedToRemote(wt.branch, wt.baseBranch);
     const unpushedCount = await getUnpushedCommitCount(wt.path, wt.branch);
     const modifiedCount = await getLocalModificationCount(wt.path);
 

--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { $ } from "bun";
+import { isBranchMergedToRemote } from "./git.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("isBranchMergedToRemote", () => {
+  test("checks merge status against the worktree base branch", async () => {
+    const previousCwd = process.cwd();
+    const originDir = makeTempDir("wt-origin-");
+    const repoRoot = makeTempDir("wt-repo-");
+    const worktreeRoot = makeTempDir("wt-worktrees-");
+    const worktreePath = join(worktreeRoot, "repo-feature");
+
+    await $`git init --bare ${originDir}`.quiet();
+    await $`git clone ${originDir} ${repoRoot}`.quiet();
+    await $`git -C ${repoRoot} config user.email test@example.com`.quiet();
+    await $`git -C ${repoRoot} config user.name tester`.quiet();
+    await $`git -C ${repoRoot} checkout -b trunk`.quiet();
+    await Bun.write(join(repoRoot, "README.md"), "base\n");
+    await $`git -C ${repoRoot} add README.md`.quiet();
+    await $`git -C ${repoRoot} commit -m base`.quiet();
+    await $`git -C ${repoRoot} push -u origin trunk`.quiet();
+    await $`git -C ${repoRoot} remote set-head origin trunk`.quiet();
+    await $`git -C ${repoRoot} worktree add -b feature/trunk-test ${worktreePath} trunk`.quiet();
+    await Bun.write(join(worktreePath, "README.md"), "feature\n");
+    await $`git -C ${worktreePath} add README.md`.quiet();
+    await $`git -C ${worktreePath} commit -m feature`.quiet();
+    await $`git -C ${worktreePath} push -u origin feature/trunk-test`.quiet();
+    await $`git -C ${repoRoot} merge --no-ff feature/trunk-test -m merge-feature`.quiet();
+    await $`git -C ${repoRoot} push origin trunk`.quiet();
+
+    process.chdir(repoRoot);
+
+    try {
+      expect(
+        await isBranchMergedToRemote("feature/trunk-test", "trunk")
+      ).toBeTrue();
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+});

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -134,9 +134,28 @@ export async function deleteBranch(branch: string): Promise<void> {
   await $`git branch -D ${branch}`;
 }
 
-export async function isBranchMergedToRemote(branch: string): Promise<boolean> {
+async function getDefaultRemoteBranch(): Promise<string | undefined> {
   try {
-    const result = await $`git branch -r --merged origin/main`.text();
+    const result = await $`git symbolic-ref refs/remotes/origin/HEAD`.text();
+    return result.trim().replace("refs/remotes/origin/", "");
+  } catch {
+    return undefined;
+  }
+}
+
+export async function isBranchMergedToRemote(
+  branch: string,
+  baseBranch?: string
+): Promise<boolean> {
+  try {
+    const mergeBaseBranch = baseBranch ?? (await getDefaultRemoteBranch());
+    if (!mergeBaseBranch) {
+      return false;
+    }
+
+    await $`git rev-parse --verify origin/${branch}`.quiet();
+
+    const result = await $`git branch -r --merged origin/${mergeBaseBranch}`.text();
     const mergedBranches = result
       .trim()
       .split("\n")


### PR DESCRIPTION
## Summary
- check merged state against the worktree base branch when it is available
- fall back to the remote default branch instead of hardcoding origin/main
- add an integration test for repositories that use trunk as the base branch

## Testing
- bun test
- bun run build