### PR TITLE
Support batch worktree removal and improve rm completion

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -185,12 +185,12 @@ wt ls
 ### worktree 제거
 
 ```bash
-wt remove <id>
+wt remove <id...>
 # 또는
-wt rm <id>
+wt rm <id...>
 ```
 
-worktree에 수정된 파일이나 push되지 않은 커밋이 남아 있으면, `wt rm`은 삭제 전에 한 번 더 확인합니다. 프롬프트를 건너뛰려면 `wt rm <id> --force`를 사용할 수 있습니다.
+worktree에 수정된 파일이나 push되지 않은 커밋이 남아 있으면, `wt rm`은 삭제 전에 한 번 더 확인합니다. 여러 worktree를 넘기면 각 대상마다 개별로 확인합니다. 프롬프트를 건너뛰려면 `wt rm <id...> --force`를 사용할 수 있습니다.
 
 다음 방법으로 worktree를 제거할 수 있습니다:
 - ID (기본값: 브랜치 이름, 예: `feature/issue-12`)

--- a/README.md
+++ b/README.md
@@ -186,12 +186,12 @@ wt ls
 ### Remove a worktree
 
 ```bash
-wt remove <id>
+wt remove <id...>
 # or
-wt rm <id>
+wt rm <id...>
 ```
 
-If the worktree has modified files or unpushed commits, `wt rm` asks for confirmation before deleting it. Use `wt rm <id> --force` to skip the prompt.
+If the worktree has modified files or unpushed commits, `wt rm` asks for confirmation before deleting it. When you pass multiple worktrees, it prompts separately for each one. Use `wt rm <id...> --force` to skip the prompts.
 
 You can remove a worktree using:
 - ID (defaults to the branch name, e.g., `feature/issue-12`)

--- a/shell/wt.bash
+++ b/shell/wt.bash
@@ -21,19 +21,22 @@ wt() {
 }
 
 _wt_completion() {
-  if [ $COMP_CWORD -eq 2 ] && {
-    [ "${COMP_WORDS[1]}" = "cd" ] ||
-    [ "${COMP_WORDS[1]}" = "rm" ] ||
-    [ "${COMP_WORDS[1]}" = "remove" ];
-  }; then
-    local extra_args=()
-    if [ "${COMP_WORDS[1]}" = "rm" ] || [ "${COMP_WORDS[1]}" = "remove" ]; then
-      extra_args=(--exclude-main-worktree)
-    fi
-    local items=$(/path/to/wt list --completion bash "${extra_args[@]}" 2>/dev/null)
-    local ids=$(echo "$items" | cut -d: -f1)
-    COMPREPLY=($(compgen -W "$ids" -- "${COMP_WORDS[2]}"))
-  fi
+  case "${COMP_WORDS[1]}" in
+    cd)
+      if [ $COMP_CWORD -eq 2 ]; then
+        local items=$(/path/to/wt list --completion bash 2>/dev/null)
+        local ids=$(echo "$items" | cut -d: -f1)
+        COMPREPLY=($(compgen -W "$ids" -- "${COMP_WORDS[2]}"))
+      fi
+      ;;
+    rm|remove)
+      if [ $COMP_CWORD -ge 2 ]; then
+        local items=$(/path/to/wt list --completion bash --exclude-main-worktree 2>/dev/null)
+        local ids=$(echo "$items" | cut -d: -f1)
+        COMPREPLY=($(compgen -W "$ids" -- "${COMP_WORDS[$COMP_CWORD]}"))
+      fi
+      ;;
+  esac
 }
 
 complete -F _wt_completion wt

--- a/src/app/use-cases/list-worktrees.ts
+++ b/src/app/use-cases/list-worktrees.ts
@@ -1,6 +1,14 @@
-import type { WorktreeInfo, WorktreeState } from "../../domain/worktree.js";
+import type {
+  WorktreeInfo,
+  WorktreeRemovalInfo,
+  WorktreeState,
+} from "../../domain/worktree.js";
 import { requireRepositoryContext } from "../repository-context.js";
-import { loadWorktreeInfos, loadWorktreeStates } from "../worktree-catalog.js";
+import {
+  loadWorktreeInfos,
+  loadWorktreeRemovalInfos,
+  loadWorktreeStates,
+} from "../worktree-catalog.js";
 
 export interface ListWorktreeInfosOptions {
   excludeMainWorktree?: boolean;
@@ -14,6 +22,11 @@ export interface ListWorktreeInfosResult {
 export interface ListWorktreesResult {
   repoName: string;
   worktrees: WorktreeState[];
+}
+
+export interface ListRemoveCompletionWorktreesResult {
+  repoName: string;
+  worktrees: WorktreeRemovalInfo[];
 }
 
 export async function listWorktreeInfos(
@@ -41,5 +54,21 @@ export async function listWorktrees(
   return {
     repoName: context.repoName,
     worktrees,
+  };
+}
+
+export async function listRemoveCompletionWorktrees(
+  cwd: string = process.cwd(),
+  options: ListWorktreeInfosOptions = {}
+): Promise<ListRemoveCompletionWorktreesResult> {
+  const context = await requireRepositoryContext(cwd);
+  const worktrees = await loadWorktreeRemovalInfos(context);
+  const visibleWorktrees = options.excludeMainWorktree
+    ? worktrees.filter((worktree) => !worktree.isMain)
+    : worktrees;
+
+  return {
+    repoName: context.repoName,
+    worktrees: visibleWorktrees,
   };
 }

--- a/src/app/worktree-catalog.ts
+++ b/src/app/worktree-catalog.ts
@@ -4,12 +4,14 @@ import type { RepositoryContext } from "./repository-context.js";
 import {
   buildWorktreeIdentifiers,
   type WorktreeInfo,
+  type WorktreeMergeStatus,
+  type WorktreeRemovalInfo,
   type WorktreeState,
 } from "../domain/worktree.js";
 import { listGitWorktrees } from "../infra/git/worktree-repository.js";
 import {
   getDefaultRemoteBranch,
-  getMergedRemoteBranches,
+  getMergedRemoteBranchesResult,
   getWorktreeStatusSummary,
 } from "../infra/git/status.js";
 import { readWorktreeMeta } from "../infra/storage/worktree-meta-store.js";
@@ -57,31 +59,11 @@ export async function loadWorktreeStates(
   context: RepositoryContext
 ): Promise<WorktreeState[]> {
   const worktrees = await loadWorktreeInfos(context);
-  const defaultRemoteBaseBranch = await getDefaultRemoteBranch(context.repoRoot);
-  const baseBranches = [
-    ...new Set(
-      worktrees
-        .map((wt) => wt.baseBranch ?? defaultRemoteBaseBranch)
-        .filter((branch): branch is string => Boolean(branch))
-    ),
-  ];
-  const mergedBranchEntries: Array<readonly [string, Set<string>]> =
-    await Promise.all(
-      baseBranches.map(
-        async (baseBranch): Promise<readonly [string, Set<string>]> => [
-        baseBranch,
-        await getMergedRemoteBranches(context.repoRoot, baseBranch),
-      ]
-      )
-    );
-  const mergedBranchesByBase = new Map<string, Set<string>>(mergedBranchEntries);
+  const mergeMetadata = await loadMergeMetadata(context, worktrees);
 
   const worktreeStates = await Promise.all(
     worktrees.map(async (worktree) => {
-      const mergeBaseBranch = worktree.baseBranch ?? defaultRemoteBaseBranch;
-      const mergedBranches = mergeBaseBranch
-        ? mergedBranchesByBase.get(mergeBaseBranch)
-        : undefined;
+      const mergeStatus = resolveWorktreeMergeStatus(worktree, mergeMetadata);
       const { unpushedCount, modifiedCount } = await getWorktreeStatusSummary(
         worktree.path,
         worktree.branch
@@ -90,7 +72,7 @@ export async function loadWorktreeStates(
       return {
         ...worktree,
         isCurrent: isPathInside(worktree.path, context.cwd),
-        isMerged: mergedBranches?.has(`origin/${worktree.branch}`) ?? false,
+        isMerged: mergeStatus === "merged",
         unpushedCount,
         modifiedCount,
       };
@@ -107,4 +89,83 @@ export async function loadWorktreeStates(
     currentWorktree,
     ...worktreeStates.filter((wt) => wt.path !== currentWorktree.path),
   ];
+}
+
+export async function loadWorktreeRemovalInfos(
+  context: RepositoryContext
+): Promise<WorktreeRemovalInfo[]> {
+  const worktrees = await loadWorktreeInfos(context);
+  const mergeMetadata = await loadMergeMetadata(context, worktrees);
+
+  return worktrees.map((worktree) => ({
+    ...worktree,
+    mergeStatus: resolveWorktreeMergeStatus(worktree, mergeMetadata),
+  }));
+}
+
+async function loadMergeMetadata(
+  context: RepositoryContext,
+  worktrees: WorktreeInfo[]
+): Promise<{
+  defaultRemoteBaseBranch?: string;
+  mergedBranchesByBase: Map<
+    string,
+    Awaited<ReturnType<typeof getMergedRemoteBranchesResult>>
+  >;
+}> {
+  const defaultRemoteBaseBranch = await getDefaultRemoteBranch(context.repoRoot);
+  const baseBranches = [
+    ...new Set(
+      worktrees
+        .map((wt) => wt.baseBranch ?? defaultRemoteBaseBranch)
+        .filter((branch): branch is string => Boolean(branch))
+    ),
+  ];
+  const mergedBranchEntries = await Promise.all(
+    baseBranches.map(
+      async (
+        baseBranch
+      ): Promise<
+        readonly [
+          string,
+          Awaited<ReturnType<typeof getMergedRemoteBranchesResult>>,
+        ]
+      > => [
+        baseBranch,
+        await getMergedRemoteBranchesResult(context.repoRoot, baseBranch),
+      ]
+    )
+  );
+
+  return {
+    defaultRemoteBaseBranch,
+    mergedBranchesByBase: new Map(mergedBranchEntries),
+  };
+}
+
+function resolveWorktreeMergeStatus(
+  worktree: WorktreeInfo,
+  mergeMetadata: {
+    defaultRemoteBaseBranch?: string;
+    mergedBranchesByBase: Map<
+      string,
+      Awaited<ReturnType<typeof getMergedRemoteBranchesResult>>
+    >;
+  }
+): WorktreeMergeStatus {
+  const mergeBaseBranch =
+    worktree.baseBranch ?? mergeMetadata.defaultRemoteBaseBranch;
+
+  if (!mergeBaseBranch) {
+    return "unknown";
+  }
+
+  const mergeResult = mergeMetadata.mergedBranchesByBase.get(mergeBaseBranch);
+  if (!mergeResult?.known) {
+    return "unknown";
+  }
+
+  return mergeResult.branches.has(`origin/${worktree.branch}`)
+    ? "merged"
+    : "not_merged";
 }

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -442,6 +442,68 @@ describe("cli e2e", () => {
     ).toBeFalse();
   });
 
+  test("includes removal metadata in completion output", async () => {
+    const repo = await createTestRepo();
+    const worktreeId = "removemeta123";
+    const branchName = "feature-remove-meta";
+    const worktreePath = getWorktreePath(repo, worktreeId);
+
+    runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
+    writeFileSync(join(worktreePath, "README.md"), "base\nremove-metadata\n");
+    await $`git -C ${worktreePath} add README.md`.quiet();
+    await $`git -C ${worktreePath} commit -m completion-meta`.quiet();
+    await $`git -C ${worktreePath} push origin ${branchName}`.quiet();
+
+    const completionResult = runCliCapture(
+      ["list", "--completion", "bash", "--exclude-main-worktree"],
+      repo.repoRoot
+    );
+    assertProcessSuccess(
+      completionResult.status,
+      completionResult.stderr,
+      completionResult.stdout
+    );
+
+    expect(completionResult.stdout).toContain(`${worktreeId}:${branchName} |`);
+    expect(completionResult.stdout).toContain("not merged");
+    expect(completionResult.stdout).toContain("from main@");
+    expect(completionResult.stdout).not.toContain("change");
+    expect(completionResult.stdout).not.toContain("unpushed");
+  });
+
+  test("omits merged status in completion output when merge status is unknown", async () => {
+    const repo = await createTestRepo();
+    const worktreeId = "removeunknown123";
+    const branchName = "feature-remove-unknown";
+    const worktreePath = getWorktreePath(repo, worktreeId);
+    const metaPath = join(worktreePath, ".wt", "meta.json");
+
+    runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
+
+    const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    meta.baseBranch = "missing-base";
+    writeFileSync(metaPath, JSON.stringify(meta, null, 2));
+
+    const completionResult = runCliCapture(
+      ["list", "--completion", "bash", "--exclude-main-worktree"],
+      repo.repoRoot
+    );
+    assertProcessSuccess(
+      completionResult.status,
+      completionResult.stderr,
+      completionResult.stdout
+    );
+
+    const completionLine = completionResult.stdout
+      .split(/\r?\n/)
+      .find(line => line.startsWith(`${worktreeId}:`));
+
+    expect(completionLine).toBeDefined();
+    expect(completionLine).toContain(`${branchName} | from missing-base`);
+    expect(completionLine).not.toContain("not merged");
+    expect(completionLine).not.toContain("merged |");
+  });
+
   test("asks for confirmation before removing a worktree with local changes", async () => {
     const repo = await createTestRepo();
     const worktreeId = "confirm123";
@@ -528,6 +590,78 @@ describe("cli e2e", () => {
     assertProcessSuccess(result.status, result.stderr, result.stdout);
     expect(result.stdout).not.toContain("Remove this worktree anyway? [y/N]");
     expect(existsSync(worktreePath)).toBeFalse();
+  });
+
+  test("removes multiple worktrees in one command", async () => {
+    const repo = await createTestRepo();
+    const firstWorktreeId = "multi123";
+    const secondWorktreeId = "multi456";
+    const firstBranchName = "feature-multi-one";
+    const secondBranchName = "feature-multi-two";
+    const firstWorktreePath = getWorktreePath(repo, firstWorktreeId);
+    const secondWorktreePath = getWorktreePath(repo, secondWorktreeId);
+
+    runCli(
+      ["new", firstBranchName, "--id", firstWorktreeId, "--no-cd"],
+      repo.repoRoot
+    );
+    runCli(
+      ["new", secondBranchName, "--id", secondWorktreeId, "--no-cd"],
+      repo.repoRoot
+    );
+
+    const result = runCliCapture(
+      ["remove", firstWorktreeId, secondWorktreeId, "--keep-branch"],
+      repo.repoRoot
+    );
+
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+    expect(result.stdout).toContain(`(${firstWorktreeId})`);
+    expect(result.stdout).toContain(`(${secondWorktreeId})`);
+    expect(existsSync(firstWorktreePath)).toBeFalse();
+    expect(existsSync(secondWorktreePath)).toBeFalse();
+  });
+
+  test("asks for confirmation for each worktree during batch removal", async () => {
+    const repo = await createTestRepo();
+    const firstWorktreeId = "batchconfirm123";
+    const secondWorktreeId = "batchconfirm456";
+    const firstBranchName = "feature-batch-confirm-one";
+    const secondBranchName = "feature-batch-confirm-two";
+    const firstWorktreePath = getWorktreePath(repo, firstWorktreeId);
+    const secondWorktreePath = getWorktreePath(repo, secondWorktreeId);
+
+    runCli(
+      ["new", firstBranchName, "--id", firstWorktreeId, "--no-cd"],
+      repo.repoRoot
+    );
+    runCli(
+      ["new", secondBranchName, "--id", secondWorktreeId, "--no-cd"],
+      repo.repoRoot
+    );
+    writeFileSync(join(firstWorktreePath, "UNTRACKED.md"), "dirty one\n");
+    writeFileSync(join(secondWorktreePath, "UNTRACKED.md"), "dirty two\n");
+
+    const result = runCliCapture(
+      ["remove", firstWorktreeId, secondWorktreeId],
+      repo.repoRoot,
+      {
+        input: "n\ny\n",
+      }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      `Warning: ${firstBranchName} (${firstWorktreeId}) has 1 local change.`
+    );
+    expect(result.stdout).toContain(
+      `Warning: ${secondBranchName} (${secondWorktreeId}) has 1 local change.`
+    );
+    expect(result.stdout).toContain(
+      `Skipped worktree: ${firstBranchName} (${firstWorktreeId})`
+    );
+    expect(existsSync(firstWorktreePath)).toBeTrue();
+    expect(existsSync(secondWorktreePath)).toBeFalse();
   });
 
   test("adds a unique suffix when sanitized ids would collide", async () => {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,8 +1,14 @@
 import chalk from "chalk";
 import {
+  listRemoveCompletionWorktrees,
   listWorktreeInfos,
   listWorktrees,
 } from "../app/use-cases/list-worktrees.js";
+import type {
+  WorktreeInfo,
+  WorktreeRemovalInfo,
+  WorktreeState,
+} from "../types/index.js";
 import { runCommand } from "../cli/command-runtime.js";
 
 type CompletionFormat = "bash" | "zsh" | "fish";
@@ -13,23 +19,35 @@ export async function listCommand(options?: {
 }): Promise<void> {
   await runCommand(async () => {
     if (options?.completion) {
-      const result = await listWorktreeInfos(process.cwd(), {
-        excludeMainWorktree: options.excludeMainWorktree,
-      });
+      const useRemovalCompletionDescriptions = options.excludeMainWorktree;
 
-      for (const worktree of result.worktrees) {
-        let description = worktree.branch;
+      if (useRemovalCompletionDescriptions) {
+        const result = await listRemoveCompletionWorktrees(process.cwd(), {
+          excludeMainWorktree: options.excludeMainWorktree,
+        });
 
-        if (worktree.baseBranch && worktree.baseCommit) {
-          description += ` from ${worktree.baseBranch}@${worktree.baseCommit.substring(0, 7)}`;
-        } else if (worktree.baseBranch) {
-          description += ` from ${worktree.baseBranch}`;
+        for (const worktree of result.worktrees) {
+          const description = buildRemoveCompletionDescription(worktree);
+
+          if (options.completion === "fish") {
+            console.log(`${worktree.id}\t${description}`);
+          } else {
+            console.log(`${worktree.id}:${description}`);
+          }
         }
+      } else {
+        const result = await listWorktreeInfos(process.cwd(), {
+          excludeMainWorktree: options.excludeMainWorktree,
+        });
 
-        if (options.completion === "fish") {
-          console.log(`${worktree.id}\t${description}`);
-        } else {
-          console.log(`${worktree.id}:${description}`);
+        for (const worktree of result.worktrees) {
+          const description = buildDefaultCompletionDescription(worktree);
+
+          if (options.completion === "fish") {
+            console.log(`${worktree.id}\t${description}`);
+          } else {
+            console.log(`${worktree.id}:${description}`);
+          }
         }
       }
       return;
@@ -87,4 +105,52 @@ export async function listCommand(options?: {
       console.log(chalk.dim("─".repeat(80)));
     }
   });
+}
+
+function buildBaseDescription(
+  worktree: Pick<WorktreeInfo, "baseBranch" | "baseCommit">
+): string | undefined {
+  if (worktree.baseBranch && worktree.baseCommit) {
+    return `from ${worktree.baseBranch}@${worktree.baseCommit.substring(0, 7)}`;
+  }
+
+  if (worktree.baseBranch) {
+    return `from ${worktree.baseBranch}`;
+  }
+
+  return undefined;
+}
+
+function buildDefaultCompletionDescription(worktree: WorktreeInfo): string {
+  const descriptionParts = [worktree.branch];
+  const baseDescription = buildBaseDescription(worktree);
+
+  if (baseDescription) {
+    descriptionParts.push(baseDescription);
+  }
+
+  return descriptionParts.join(" ");
+}
+
+function buildRemoveCompletionDescription(
+  worktree: WorktreeRemovalInfo
+): string {
+  const metadata: string[] = [];
+
+  if (worktree.mergeStatus === "merged") {
+    metadata.push("merged");
+  } else if (worktree.mergeStatus === "not_merged") {
+    metadata.push("not merged");
+  }
+
+  const baseDescription = buildBaseDescription(worktree);
+  if (baseDescription) {
+    metadata.push(baseDescription);
+  }
+
+  if (metadata.length === 0) {
+    return worktree.branch;
+  }
+
+  return `${worktree.branch} | ${metadata.join(" | ")}`;
 }

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import { readFileSync } from "fs";
 import { createInterface } from "readline/promises";
 import { AppError } from "../app/errors.js";
 import {
@@ -6,9 +7,21 @@ import {
   removeWorktree,
 } from "../app/use-cases/remove-worktree.js";
 import { runCommand } from "../cli/command-runtime.js";
+
 interface RemoveCommandOptions {
   keepBranch?: boolean;
   force?: boolean;
+}
+
+interface RemovalPrompter {
+  confirmRemoval: (
+    worktreeId: string,
+    branch: string,
+    localChangeCount: number,
+    localCommitCount: number,
+    hasUnknownLocalCommits: boolean
+  ) => Promise<boolean>;
+  close: () => void;
 }
 
 function buildPendingWorkSummary(
@@ -39,78 +52,168 @@ function buildPendingWorkSummary(
   return details.join(" and ");
 }
 
-async function confirmRemoval(
-  worktreeId: string,
-  branch: string,
-  localChangeCount: number,
-  localCommitCount: number,
-  hasUnknownLocalCommits: boolean
-): Promise<boolean> {
-  const summary = buildPendingWorkSummary(
-    localChangeCount,
-    localCommitCount,
-    hasUnknownLocalCommits
-  );
-  const readline = createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
+function createRemovalPrompter(): RemovalPrompter {
+  let readline: ReturnType<typeof createInterface> | undefined;
+  let bufferedAnswers: string[] | undefined;
 
-  try {
-    console.log(
-      chalk.yellow(
-        `Warning: ${branch} (${worktreeId}) has ${summary}.`
-      )
-    );
-    const answer = await readline.question(
-      chalk.yellow("Remove this worktree anyway? [y/N] ")
-    );
+  const getReadline = () => {
+    if (!readline) {
+      readline = createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+    }
 
-    return /^(y|yes)$/i.test(answer.trim());
-  } catch {
-    return false;
-  } finally {
-    readline.close();
-  }
-}
+    return readline;
+  };
 
-export async function removeCommand(id: string, options: RemoveCommandOptions): Promise<void> {
-  await runCommand(async () => {
-    const preview = await inspectRemoveWorktree(id);
-    const hasPendingWork =
-      preview.localChangeCount > 0 ||
-      preview.localCommitCount > 0 ||
-      preview.hasUnknownLocalCommits;
+  const getBufferedAnswers = () => {
+    if (!bufferedAnswers) {
+      bufferedAnswers = readFileSync(0, "utf-8").split(/\r?\n/);
+    }
 
-    if (hasPendingWork && !options.force) {
-      const confirmed = await confirmRemoval(
-        preview.worktree.id,
-        preview.worktree.branch,
-        preview.localChangeCount,
-        preview.localCommitCount,
-        preview.hasUnknownLocalCommits
+    return bufferedAnswers;
+  };
+
+  return {
+    async confirmRemoval(
+      worktreeId: string,
+      branch: string,
+      localChangeCount: number,
+      localCommitCount: number,
+      hasUnknownLocalCommits: boolean
+    ): Promise<boolean> {
+      const summary = buildPendingWorkSummary(
+        localChangeCount,
+        localCommitCount,
+        hasUnknownLocalCommits
       );
 
-      if (!confirmed) {
+      try {
+        console.log(
+          chalk.yellow(
+            `Warning: ${branch} (${worktreeId}) has ${summary}.`
+          )
+        );
+        const prompt = chalk.yellow("Remove this worktree anyway? [y/N] ");
+        const answer = process.stdin.isTTY
+          ? await getReadline().question(prompt)
+          : (() => {
+              process.stdout.write(prompt);
+              return getBufferedAnswers().shift() ?? "";
+            })();
+
+        return /^(y|yes)$/i.test(answer.trim());
+      } catch {
+        return false;
+      }
+    },
+    close() {
+      readline?.close();
+    },
+  };
+}
+
+function hasPendingWork(preview: Awaited<ReturnType<typeof inspectRemoveWorktree>>): boolean {
+  return (
+    preview.localChangeCount > 0 ||
+    preview.localCommitCount > 0 ||
+    preview.hasUnknownLocalCommits
+  );
+}
+
+function logRemovalResult(
+  result: Awaited<ReturnType<typeof removeWorktree>>
+): void {
+  console.log(
+    chalk.blue(
+      `Removing worktree: ${result.worktree.branch} (${result.worktree.id})...`
+    )
+  );
+  console.log(chalk.green(`✓ Worktree removed`));
+
+  if (result.branchDeleted) {
+    console.log(chalk.blue(`Deleting branch: ${result.worktree.branch}...`));
+    console.log(chalk.green(`✓ Branch deleted`));
+    return;
+  }
+
+  console.log(chalk.yellow(`Branch ${result.worktree.branch} kept`));
+}
+
+async function removeSingleWorktree(
+  id: string,
+  options: RemoveCommandOptions,
+  batchMode: boolean,
+  prompter: RemovalPrompter
+): Promise<"removed" | "skipped"> {
+  const preview = await inspectRemoveWorktree(id);
+
+  if (hasPendingWork(preview) && !options.force) {
+    const confirmed = await prompter.confirmRemoval(
+      preview.worktree.id,
+      preview.worktree.branch,
+      preview.localChangeCount,
+      preview.localCommitCount,
+      preview.hasUnknownLocalCommits
+    );
+
+    if (!confirmed) {
+      if (!batchMode) {
         throw new AppError("Removal cancelled");
       }
+
+      console.log(
+        chalk.yellow(
+          `Skipped worktree: ${preview.worktree.branch} (${preview.worktree.id})`
+        )
+      );
+      return "skipped";
     }
+  }
 
-    const result = await removeWorktree(id, options);
+  const result = await removeWorktree(preview.worktree.id, options);
+  logRemovalResult(result);
+  return "removed";
+}
 
-    console.log(
-      chalk.blue(
-        `Removing worktree: ${result.worktree.branch} (${result.worktree.id})...`
-      )
-    );
-    console.log(chalk.green(`✓ Worktree removed`));
+export async function removeCommand(
+  ids: string[],
+  options: RemoveCommandOptions
+): Promise<void> {
+  await runCommand(async () => {
+    const prompter = createRemovalPrompter();
 
-    if (result.branchDeleted) {
-      console.log(chalk.blue(`Deleting branch: ${result.worktree.branch}...`));
-      console.log(chalk.green(`✓ Branch deleted`));
-      return;
+    try {
+      if (ids.length === 1) {
+        await removeSingleWorktree(ids[0], options, false, prompter);
+        return;
+      }
+
+      let hadSkippedOrFailedTargets = false;
+
+      for (const [index, id] of ids.entries()) {
+        if (index > 0) {
+          console.log("");
+        }
+
+        try {
+          const result = await removeSingleWorktree(id, options, true, prompter);
+          if (result === "skipped") {
+            hadSkippedOrFailedTargets = true;
+          }
+        } catch (error) {
+          hadSkippedOrFailedTargets = true;
+          const message = error instanceof Error ? error.message : String(error);
+          console.error(chalk.red(`Error removing "${id}": ${message}`));
+        }
+      }
+
+      if (hadSkippedOrFailedTargets) {
+        process.exitCode = 1;
+      }
+    } finally {
+      prompter.close();
     }
-
-    console.log(chalk.yellow(`Branch ${result.worktree.branch} kept`));
   });
 }

--- a/src/domain/worktree.ts
+++ b/src/domain/worktree.ts
@@ -33,6 +33,12 @@ export interface WorktreeState extends WorktreeInfo {
   modifiedCount: number;
 }
 
+export type WorktreeMergeStatus = "merged" | "not_merged" | "unknown";
+
+export interface WorktreeRemovalInfo extends WorktreeInfo {
+  mergeStatus: WorktreeMergeStatus;
+}
+
 export function toWorktreePathSegment(value: string): string {
   return value.replaceAll("/", "-");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,9 @@ program
   .action(listCommand);
 
 program
-  .command("remove <id>")
+  .command("remove <ids...>")
   .alias("rm")
-  .description("Remove a worktree by ID")
+  .description("Remove one or more worktrees by ID")
   .option("--keep-branch", "Keep the branch after removing worktree")
   .option("-f, --force", "Skip confirmation for worktrees with pending changes")
   .action(removeCommand);

--- a/src/infra/git/status.ts
+++ b/src/infra/git/status.ts
@@ -6,6 +6,11 @@ export interface WorktreeRemovalStatusSummary {
   hasUnknownLocalCommits: boolean;
 }
 
+export interface MergedRemoteBranchesResult {
+  branches: Set<string>;
+  known: boolean;
+}
+
 export async function getDefaultRemoteBranch(
   repoRoot: string
 ): Promise<string | undefined> {
@@ -18,32 +23,48 @@ export async function getDefaultRemoteBranch(
   }
 }
 
-export async function getMergedRemoteBranches(
+export async function getMergedRemoteBranchesResult(
   repoRoot: string,
   baseBranch?: string
-): Promise<Set<string>> {
+): Promise<MergedRemoteBranchesResult> {
   try {
     const mergeBaseBranch =
       baseBranch ?? (await getDefaultRemoteBranch(repoRoot));
 
     if (!mergeBaseBranch) {
-      return new Set();
+      return {
+        branches: new Set(),
+        known: false,
+      };
     }
 
     const result =
       await $`git -C ${repoRoot} branch -r --merged origin/${mergeBaseBranch}`
         .text();
 
-    return new Set(
-      result
-        .trim()
-        .split("\n")
-        .map((branch) => branch.trim())
-        .filter((branch) => branch.length > 0)
-    );
+    return {
+      branches: new Set(
+        result
+          .trim()
+          .split("\n")
+          .map((branch) => branch.trim())
+          .filter((branch) => branch.length > 0)
+      ),
+      known: true,
+    };
   } catch {
-    return new Set();
+    return {
+      branches: new Set(),
+      known: false,
+    };
   }
+}
+
+export async function getMergedRemoteBranches(
+  repoRoot: string,
+  baseBranch?: string
+): Promise<Set<string>> {
+  return (await getMergedRemoteBranchesResult(repoRoot, baseBranch)).branches;
 }
 
 export async function isBranchMergedToRemote(
@@ -51,8 +72,8 @@ export async function isBranchMergedToRemote(
   branch: string,
   baseBranch?: string
 ): Promise<boolean> {
-  const mergedBranches = await getMergedRemoteBranches(repoRoot, baseBranch);
-  return mergedBranches.has(`origin/${branch}`);
+  const result = await getMergedRemoteBranchesResult(repoRoot, baseBranch);
+  return result.known && result.branches.has(`origin/${branch}`);
 }
 
 export async function getWorktreeStatusSummary(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,8 @@ export type {
 } from "../domain/settings.js";
 export type {
   WorktreeInfo,
+  WorktreeMergeStatus,
   WorktreeMeta,
+  WorktreeRemovalInfo,
   WorktreeState,
 } from "../domain/worktree.js";

--- a/src/utils/shell-wrapper.test.ts
+++ b/src/utils/shell-wrapper.test.ts
@@ -135,7 +135,8 @@ function runWrapper(
 
 function runCompletion(
   shellCase: ShellCase,
-  subcommand: "cd" | "rm" | "remove"
+  subcommand: "cd" | "rm" | "remove",
+  precedingArgs: string[] = []
 ): CompletionRunResult {
   const tempDir = mkdtempSync(join(tmpdir(), "wt-shell-completion-"));
 
@@ -185,13 +186,13 @@ function runCompletion(
       shellCase.name === "fish"
         ? [
             'source "$WRAPPER_PATH"',
-            `complete --do-complete "wt ${subcommand} "`,
+            `complete --do-complete "wt ${subcommand}${precedingArgs.length > 0 ? ` ${precedingArgs.join(" ")}` : ""} "`,
           ].join("\n")
         : shellCase.name === "bash"
         ? [
             'source "$WRAPPER_PATH"',
-            `COMP_WORDS=(wt ${subcommand} "")`,
-            "COMP_CWORD=2",
+            `COMP_WORDS=(wt ${subcommand}${precedingArgs.length > 0 ? ` ${precedingArgs.join(" ")}` : ""} "")`,
+            `COMP_CWORD=${precedingArgs.length + 2}`,
             "_wt_completion",
             'printf \'%s\\n\' "${COMPREPLY[@]}"',
           ].join("\n")
@@ -316,6 +317,15 @@ describe("shell wrappers", () => {
 
     test(`${shellCase.scriptName} completes worktree ids for rm`, () => {
       const result = runCompletion(shellCase, "rm");
+
+      assertCompletionProcess(result);
+      expect(result.suggestions).not.toContain("main");
+      expect(result.suggestions).toContain("demo");
+      expect(result.suggestions).toContain("sample");
+    });
+
+    test(`${shellCase.scriptName} completes additional worktree ids for rm`, () => {
+      const result = runCompletion(shellCase, "rm", ["demo"]);
 
       assertCompletionProcess(result);
       expect(result.suggestions).not.toContain("main");


### PR DESCRIPTION
## Summary
- allow `wt remove`/`wt rm` to accept multiple worktree targets and confirm each target individually
- improve remove completion metadata while keeping `cd` completion behavior unchanged
- add coverage for batch removal, richer completion output, and unknown merge-state completion handling

## Testing
- bun test
- bunx tsc --noEmit