### PR TITLE
fix: keep worktree .wt artifacts out of git status

### DIFF
--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -1266,6 +1266,58 @@ describe("cli e2e", () => {
     expect(postLines[6]).toBe("missing");
   });
 
+  test("keeps .wt artifacts out of git status after async post scripts finish", async () => {
+    const repo = await createTestRepo();
+    const worktreeId = "async-clean";
+    const branchName = "feature-async-clean";
+    const worktreePath = getWorktreePath(repo, worktreeId);
+
+    updateSettings(repo.repoRoot, settings => {
+      settings.scripts = {
+        pre: [],
+        post: [
+          "sleep 0.1",
+          "printf 'done\\n' > .wt/post-complete.txt",
+        ],
+        postMode: "async",
+      };
+    });
+
+    const result = runCliCapture(
+      ["new", branchName, "--id", worktreeId, "--no-cd"],
+      repo.repoRoot
+    );
+
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+
+    const statusFilePath = join(worktreePath, ".wt", "post-task.json");
+
+    await waitFor(() => {
+      if (!existsSync(statusFilePath)) {
+        return false;
+      }
+
+      const status = JSON.parse(readFileSync(statusFilePath, "utf-8")) as {
+        status: string;
+      };
+
+      return status.status === "done";
+    });
+
+    const gitStatus = spawnSync(
+      "git",
+      ["-C", worktreePath, "status", "--short"],
+      {
+        encoding: "utf-8",
+      }
+    );
+
+    assertProcessSuccess(gitStatus.status, gitStatus.stderr, gitStatus.stdout);
+    expect(gitStatus.stdout.trim()).toBe("");
+    expect(existsSync(join(worktreePath, ".wt", "post-task.log"))).toBeTrue();
+    expect(existsSync(join(worktreePath, ".wt", "post-complete.txt"))).toBeTrue();
+  });
+
   test("sends a macOS notification when async post scripts finish", async () => {
     if (process.platform !== "darwin") {
       return;

--- a/src/infra/storage/worktree-meta-store.test.ts
+++ b/src/infra/storage/worktree-meta-store.test.ts
@@ -9,6 +9,7 @@ import {
 import { tmpdir } from "os";
 import { join } from "path";
 import {
+  WORKTREE_GITIGNORE_CONTENT,
   readWorktreeMeta,
   writeWorktreeMeta,
 } from "./worktree-meta-store.js";
@@ -52,7 +53,7 @@ describe("worktree meta store", () => {
     });
     expect(
       readFileSync(join(worktreePath, ".wt", ".gitignore"), "utf-8")
-    ).toBe(".gitignore\nmeta.json\n");
+    ).toBe(WORKTREE_GITIGNORE_CONTENT);
   });
 
   test("reads the legacy meta file for backwards compatibility", async () => {

--- a/src/infra/storage/worktree-meta-store.ts
+++ b/src/infra/storage/worktree-meta-store.ts
@@ -5,6 +5,7 @@ import type { WorktreeMeta } from "../../domain/worktree.js";
 export const WORKTREE_DIRNAME = ".wt";
 export const WORKTREE_META_FILENAME = "meta.json";
 export const LEGACY_WORKTREE_META_FILENAME = "meta";
+export const WORKTREE_GITIGNORE_CONTENT = ".gitignore\n*\n";
 
 export async function readWorktreeMeta(
   worktreePath: string
@@ -50,5 +51,5 @@ export async function writeWorktreeMeta(
     join(wtDir, WORKTREE_META_FILENAME),
     JSON.stringify(meta, null, 2)
   );
-  writeFileSync(join(wtDir, ".gitignore"), ".gitignore\nmeta.json\n");
+  writeFileSync(join(wtDir, ".gitignore"), WORKTREE_GITIGNORE_CONTENT);
 }


### PR DESCRIPTION
## Summary
- ignore all worktree-local `.wt` artifacts so async status/log files and script output do not show up as untracked changes
- keep the `.wt/.gitignore` contract explicit via a shared constant and updated unit coverage
- add an async post-script e2e regression test that verifies `git status --short` stays clean

## Testing
- bun run typecheck
- bun test

Closes #42