### PR TITLE
Add PR links to worktree list output

### DIFF
--- a/src/app/use-cases/create-pr-worktree.ts
+++ b/src/app/use-cases/create-pr-worktree.ts
@@ -206,6 +206,8 @@ export async function createPrWorktree(
     createWorktreeMeta(baseBranch, baseCommit, undefined, {
       id,
       fullId,
+      prNumber: pullRequestInfo.number,
+      prUrl: pullRequestInfo.url,
     })
   );
 

--- a/src/app/use-cases/list-worktrees.ts
+++ b/src/app/use-cases/list-worktrees.ts
@@ -4,6 +4,7 @@ import type {
   WorktreeState,
 } from "../../domain/worktree.js";
 import { requireRepositoryContext } from "../repository-context.js";
+import { listPullRequestLinks } from "../../infra/github/cli.js";
 import {
   loadWorktreeInfos,
   loadWorktreeRemovalInfos,
@@ -29,6 +30,39 @@ export interface ListRemoveCompletionWorktreesResult {
   worktrees: WorktreeRemovalInfo[];
 }
 
+async function enrichWorktreesWithPullRequests<T extends WorktreeInfo>(
+  repoRoot: string,
+  worktrees: T[]
+): Promise<T[]> {
+  const shouldResolvePullRequests = worktrees.some(
+    (worktree) => !worktree.prUrl && worktree.branch && !worktree.isDetached
+  );
+
+  if (!shouldResolvePullRequests) {
+    return worktrees;
+  }
+
+  const pullRequestsByBranch = await listPullRequestLinks(repoRoot);
+
+  return worktrees.map((worktree) => {
+    if (worktree.prUrl || !worktree.branch || worktree.isDetached) {
+      return worktree;
+    }
+
+    const pullRequest = pullRequestsByBranch.get(worktree.branch);
+
+    if (!pullRequest) {
+      return worktree;
+    }
+
+    return {
+      ...worktree,
+      prNumber: pullRequest.number,
+      prUrl: pullRequest.url,
+    };
+  });
+}
+
 export async function listWorktreeInfos(
   cwd: string = process.cwd(),
   options: ListWorktreeInfosOptions = {}
@@ -49,7 +83,10 @@ export async function listWorktrees(
   cwd: string = process.cwd()
 ): Promise<ListWorktreesResult> {
   const context = await requireRepositoryContext(cwd);
-  const worktrees = await loadWorktreeStates(context);
+  const worktrees = await enrichWorktreesWithPullRequests(
+    context.repoRoot,
+    await loadWorktreeStates(context)
+  );
 
   return {
     repoName: context.repoName,

--- a/src/app/use-cases/uninstall-installation.test.ts
+++ b/src/app/use-cases/uninstall-installation.test.ts
@@ -74,6 +74,7 @@ describe("uninstall installation use case", () => {
         argv0: "bun",
         execPath: "/Users/test/.bun/bin/bun",
       },
+      standaloneBinaryPath: "/Users/test/.local/bin/missing-wt",
       isHomebrewInstallAvailable: () => true,
       onBeforeHomebrewUninstall: (command) => delegatedCommands.push(command),
       runHomebrewUninstall: (plan) => {
@@ -146,6 +147,7 @@ describe("uninstall installation use case", () => {
           argv0: "bun",
           execPath: "/Users/test/.bun/bin/bun",
         },
+        standaloneBinaryPath: "/Users/test/.local/bin/missing-wt",
         isHomebrewInstallAvailable: () => false,
       })
     ).toThrow(

--- a/src/app/worktree-catalog.ts
+++ b/src/app/worktree-catalog.ts
@@ -57,6 +57,8 @@ export async function loadWorktreeInfos(
         createdAt: resolveCreatedAt(worktree.path, meta?.createdAt),
         baseBranch: meta?.baseBranch,
         baseCommit: meta?.baseCommit,
+        prNumber: meta?.prNumber,
+        prUrl: meta?.prUrl,
       };
     })
   );

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -50,6 +50,8 @@ interface FakeGithubCliOptions {
   headBranch?: string;
   headRefOid?: string;
   logPath?: string;
+  prNumber?: string;
+  prUrl?: string;
 }
 
 const tempDirs: string[] = [];
@@ -239,6 +241,9 @@ function createFakeGithubEnv(
   const headBranch = options.headBranch ?? "feature/pr-123";
   const headRefOid =
     options.headRefOid ?? "0000000000000000000000000000000000000000";
+  const prNumber = options.prNumber ?? "123";
+  const prUrl =
+    options.prUrl ?? `https://github.com/example/repo/pull/${prNumber}`;
 
   mkdirSync(binDir, { recursive: true });
 
@@ -276,7 +281,20 @@ function createFakeGithubEnv(
         ...authScript.map((line) => `  ${line}`),
         "fi",
         'if [ "$1" = "pr" ] && [ "${2:-}" = "view" ]; then',
-        `  printf '%s\\n' '{"baseRefName":"${baseBranch}","headRefName":"${headBranch}","headRefOid":"${headRefOid}"}'`,
+        "  selector=$3",
+        `  if [ "$selector" = "${headBranch}" ]; then`,
+          `    printf '%s\\n' '{"number":${prNumber},"url":"${prUrl}"}'`,
+        "    exit 0",
+        "  fi",
+        `  if [ "$selector" = "${prNumber}" ]; then`,
+        `    printf '%s\\n' '{"baseRefName":"${baseBranch}","headRefName":"${headBranch}","headRefOid":"${headRefOid}","number":${prNumber},"url":"${prUrl}"}'`,
+        "    exit 0",
+        "  fi",
+        '  echo "no pull request found" >&2',
+        "  exit 1",
+        "fi",
+        'if [ "$1" = "pr" ] && [ "${2:-}" = "list" ]; then',
+        `  printf '%s\\n' '[{"number":${prNumber},"url":"${prUrl}","headRefName":"${headBranch}"}]'`,
         "  exit 0",
         "fi",
         'if [ "$1" = "pr" ] && [ "${2:-}" = "checkout" ]; then',
@@ -1480,6 +1498,59 @@ describe("cli e2e", () => {
 
     expect(mainIdLine).toBe(`ID:      ${mainWorktreeId} [main]`);
     expect(linkedIdLine).toBe(`ID:      ${worktreeId} (current)`);
+  });
+
+  test("shows a linked pull request URL in list output for a branch worktree", async () => {
+    const repo = await createTestRepo();
+    const worktreeId = "prlink123";
+    const branchName = "feature-pr-link";
+    const prUrl = "https://github.com/example/repo/pull/456";
+    const ghLogPath = join(repo.repoRoot, "gh.log");
+
+    runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
+
+    const result = runCliCapture(["list"], repo.repoRoot, {
+      env: createFakeGithubEnv({
+        headBranch: branchName,
+        logPath: ghLogPath,
+        prNumber: "456",
+        prUrl,
+      }),
+    });
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+
+    const ghLog = readFileSync(ghLogPath, "utf-8");
+
+    expect(result.stdout).toContain(`ID:      ${worktreeId}`);
+    expect(result.stdout).toContain(`PR:      #456 ${prUrl}`);
+    expect(ghLog).toContain("pr list --state open --limit 1000 --json number,url,headRefName");
+    expect(ghLog).not.toContain(`pr view ${branchName}`);
+  });
+
+  test("shows stored pull request URLs in list output for PR worktrees", async () => {
+    const repo = await createTestRepo();
+    const prNumber = "789";
+    const branchName = "feature-pr-worktree-link";
+    const prUrl = "https://github.com/example/repo/pull/789";
+
+    const createResult = runCliCapture(["pr", prNumber, "--no-cd"], repo.repoRoot, {
+      env: createFakeGithubEnv({
+        headBranch: branchName,
+        prNumber,
+        prUrl,
+      }),
+    });
+    assertProcessSuccess(
+      createResult.status,
+      createResult.stderr,
+      createResult.stdout
+    );
+
+    const listResult = runCliCapture(["list"], repo.repoRoot);
+    assertProcessSuccess(listResult.status, listResult.stderr, listResult.stdout);
+
+    expect(listResult.stdout).toContain(`ID:      pr-${prNumber}`);
+    expect(listResult.stdout).toContain(`PR:      #${prNumber} ${prUrl}`);
   });
 
   test("lists a detached main worktree instead of hiding it", async () => {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -87,12 +87,16 @@ export async function listCommand(options?: {
 
     for (const worktree of result.worktrees) {
       const idLabel = buildWorktreeIdLabel(worktree);
+      const pullRequestSummary = buildPullRequestSummary(worktree);
       const timestamp = new Date(worktree.createdAt).toLocaleString();
 
       console.log(chalk.cyan(`ID:      ${idLabel}`));
       console.log(
         chalk.white(`Branch:  ${buildWorktreeBranchSummary(worktree)}`)
       );
+      if (pullRequestSummary) {
+        console.log(`PR:      ${pullRequestSummary}`);
+      }
       console.log(chalk.dim(`Path:    ${worktree.path}`));
       console.log(chalk.dim(`Created: ${timestamp}`));
       console.log(chalk.dim("─".repeat(80)));
@@ -132,4 +136,16 @@ function buildRemoveCompletionDescription(
   }
 
   return `${getWorktreeBranchLabel(worktree)} | ${metadata.join(" | ")}`;
+}
+
+function buildPullRequestSummary(
+  worktree: Pick<WorktreeState, "prNumber" | "prUrl">
+): string | undefined {
+  if (!worktree.prUrl) {
+    return undefined;
+  }
+
+  return worktree.prNumber
+    ? `#${worktree.prNumber} ${worktree.prUrl}`
+    : worktree.prUrl;
 }

--- a/src/domain/worktree.test.ts
+++ b/src/domain/worktree.test.ts
@@ -67,4 +67,23 @@ describe("worktree domain", () => {
       })
     ).toBe("(detached) @ abc1234");
   });
+
+  test("preserves pull request metadata in stored worktree meta", () => {
+    expect(
+      createWorktreeMeta("main", "abc123", "2026-03-16T00:00:00.000Z", {
+        id: "pr-123",
+        fullId: "repo-pr-123",
+        prNumber: "123",
+        prUrl: "https://github.com/example/repo/pull/123",
+      })
+    ).toEqual({
+      baseBranch: "main",
+      baseCommit: "abc123",
+      createdAt: "2026-03-16T00:00:00.000Z",
+      id: "pr-123",
+      fullId: "repo-pr-123",
+      prNumber: "123",
+      prUrl: "https://github.com/example/repo/pull/123",
+    });
+  });
 });

--- a/src/domain/worktree.ts
+++ b/src/domain/worktree.ts
@@ -8,6 +8,8 @@ export interface WorktreeMeta {
   createdAt: string;
   id?: string;
   fullId?: string;
+  prNumber?: string;
+  prUrl?: string;
 }
 
 export interface GitWorktreeRef {
@@ -30,6 +32,8 @@ export interface WorktreeInfo {
   createdAt: string;
   baseBranch?: string;
   baseCommit?: string;
+  prNumber?: string;
+  prUrl?: string;
 }
 
 export interface WorktreeState extends WorktreeInfo {
@@ -124,12 +128,12 @@ export function createWorktreeMeta(
   baseBranch: string,
   baseCommit: string,
   createdAt: string = new Date().toISOString(),
-  identifiers?: Pick<WorktreeInfo, "id" | "fullId">
+  metadata?: Pick<WorktreeInfo, "fullId" | "id" | "prNumber" | "prUrl">
 ): WorktreeMeta {
   return {
     baseBranch,
     baseCommit,
     createdAt,
-    ...identifiers,
+    ...metadata,
   };
 }

--- a/src/infra/github/cli.ts
+++ b/src/infra/github/cli.ts
@@ -12,6 +12,19 @@ export interface PullRequestInfo {
   baseRefName: string;
   headRefName: string;
   headRefOid: string;
+  number: string;
+  url: string;
+}
+
+export interface PullRequestLink {
+  number: string;
+  url: string;
+}
+
+interface PullRequestListEntry {
+  headRefName: string;
+  number: number;
+  url: string;
 }
 
 function runGithubCommand(
@@ -75,7 +88,7 @@ export async function getPullRequestInfo(
       "view",
       pullRequestNumber,
       "--json",
-      "baseRefName,headRefName,headRefOid",
+      "baseRefName,headRefName,headRefOid,number,url",
     ],
     repoRoot
   );
@@ -86,15 +99,27 @@ export async function getPullRequestInfo(
     );
   }
 
-  let info: Partial<PullRequestInfo>;
+  let info: Partial<{
+    baseRefName: string;
+    headRefName: string;
+    headRefOid: string;
+    number: number;
+    url: string;
+  }>;
 
   try {
-    info = JSON.parse(result.stdout) as Partial<PullRequestInfo>;
+    info = JSON.parse(result.stdout) as typeof info;
   } catch {
     throw new AppError(`Could not parse PR #${pullRequestNumber} details from GitHub CLI`);
   }
 
-  if (!info.baseRefName || !info.headRefName || !info.headRefOid) {
+  if (
+    !info.baseRefName ||
+    !info.headRefName ||
+    !info.headRefOid ||
+    typeof info.number !== "number" ||
+    !info.url
+  ) {
     throw new AppError(`Could not determine branch information for PR #${pullRequestNumber}`);
   }
 
@@ -102,7 +127,71 @@ export async function getPullRequestInfo(
     baseRefName: info.baseRefName,
     headRefName: info.headRefName,
     headRefOid: info.headRefOid,
+    number: String(info.number),
+    url: info.url,
   };
+}
+
+export async function listPullRequestLinks(
+  repoRoot: string
+): Promise<Map<string, PullRequestLink>> {
+  const result = runGithubCommand(
+    [
+      "pr",
+      "list",
+      "--state",
+      "open",
+      "--limit",
+      "1000",
+      "--json",
+      "number,url,headRefName",
+    ],
+    repoRoot
+  );
+
+  if (result.status !== 0) {
+    return new Map();
+  }
+
+  let entries: Partial<PullRequestListEntry>[];
+
+  try {
+    entries = JSON.parse(result.stdout) as Partial<PullRequestListEntry>[];
+  } catch {
+    return new Map();
+  }
+
+  if (!Array.isArray(entries)) {
+    return new Map();
+  }
+
+  const linksByBranch = new Map<string, PullRequestLink | null>();
+
+  for (const entry of entries) {
+    if (
+      !entry.headRefName ||
+      typeof entry.number !== "number" ||
+      !entry.url
+    ) {
+      continue;
+    }
+
+    if (linksByBranch.has(entry.headRefName)) {
+      linksByBranch.set(entry.headRefName, null);
+      continue;
+    }
+
+    linksByBranch.set(entry.headRefName, {
+      number: String(entry.number),
+      url: entry.url,
+    });
+  }
+
+  return new Map(
+    [...linksByBranch.entries()].filter(
+      (entry): entry is [string, PullRequestLink] => entry[1] !== null
+    )
+  );
 }
 
 export async function checkoutPullRequest(

--- a/src/infra/storage/worktree-meta-store.test.ts
+++ b/src/infra/storage/worktree-meta-store.test.ts
@@ -38,6 +38,8 @@ describe("worktree meta store", () => {
       createdAt: "2026-03-15T00:00:00.000Z",
       id: "feature/issue-12",
       fullId: "repo-feature/issue-12",
+      prNumber: "123",
+      prUrl: "https://github.com/example/repo/pull/123",
     });
 
     expect(
@@ -50,6 +52,8 @@ describe("worktree meta store", () => {
       createdAt: "2026-03-15T00:00:00.000Z",
       id: "feature/issue-12",
       fullId: "repo-feature/issue-12",
+      prNumber: "123",
+      prUrl: "https://github.com/example/repo/pull/123",
     });
     expect(
       readFileSync(join(worktreePath, ".wt", ".gitignore"), "utf-8")
@@ -67,6 +71,8 @@ describe("worktree meta store", () => {
         baseBranch: "trunk",
         baseCommit: "def456",
         createdAt: "2026-03-15T01:00:00.000Z",
+        prNumber: "456",
+        prUrl: "https://github.com/example/repo/pull/456",
       })
     );
 
@@ -74,6 +80,8 @@ describe("worktree meta store", () => {
       baseBranch: "trunk",
       baseCommit: "def456",
       createdAt: "2026-03-15T01:00:00.000Z",
+      prNumber: "456",
+      prUrl: "https://github.com/example/repo/pull/456",
     });
   });
 });


### PR DESCRIPTION
## Summary
- show linked PR URLs in `wt list` output so terminals can cmd-click them
- switch live PR resolution from per-worktree `gh pr view` calls to one repo-level `gh pr list` call
- persist PR metadata for PR-created worktrees and harden related tests, including uninstall test isolation

## Testing
- `bun test`
- `bunx tsc --noEmit`