### PR TITLE
Add worktree ID rename command

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -8,6 +8,7 @@ pre/post 스크립트 지원이 포함된 git worktree 관리 CLI 도구입니�
 
 - 🚀 브랜치 기반 ID와 저장소 기반 이름으로 worktree 생성
 - 🎯 새 worktree로 자동 이동 (shell wrapper 통합)
+- ✏️ 디렉터리는 그대로 두고 worktree ID 변경
 - ⚙️ 저장소별로 worktree 기본 디렉토리, 기본 브랜치, 원격 푸시 동작 설정
 - 🔄 worktree 생성 전 최신 변경사항 자동 fetch
 - 📤 기본적으로 원격에 자동 푸시 (`--no-push` 플래그로 비활성화)
@@ -265,6 +266,14 @@ wt list
 wt ls
 ```
 
+### 현재 worktree ID 변경
+
+```bash
+wt rename new-name
+```
+
+`wt rename`은 현재 디렉터리가 속한 worktree의 ID만 변경합니다. 실제 worktree 디렉터리 이름이나 경로는 바꾸지 않습니다. 새 ID는 저장소의 다른 worktree와 충돌하지 않아야 하며, main worktree는 변경할 수 없습니다.
+
 ### worktree 제거
 
 ```bash
@@ -453,6 +462,7 @@ wt/
 │   │   ├── pr.ts              # wt pr
 │   │   ├── list.ts            # wt list / wt ls
 │   │   ├── remove.ts          # wt remove / wt rm
+│   │   ├── rename.ts          # wt rename
 │   │   ├── clean.ts           # wt clean
 │   │   ├── cd.ts              # wt cd
 │   │   ├── shell.ts           # wt shell install

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A CLI tool to manage git worktrees with pre/post script support.
 
 - 🚀 Create worktrees with branch-based IDs and repo-based naming
 - 🎯 Auto-cd to new worktree (with shell wrapper integration)
+- ✏️ Rename a worktree ID without moving its directory
 - ⚙️ Configure worktree base directory, base branch, and remote push behavior per repository
 - 🔄 Auto-fetch latest changes before creating worktree
 - 📤 Auto-push to remote by default (disable with `--no-push` flag)
@@ -265,6 +266,14 @@ wt list
 wt ls
 ```
 
+### Rename the current worktree ID
+
+```bash
+wt rename new-name
+```
+
+`wt rename` updates the ID for the worktree containing your current directory. It does not move or rename the worktree directory. The new ID must be unique across the repository's worktrees, and the main worktree cannot be renamed.
+
 ### Remove a worktree
 
 ```bash
@@ -452,6 +461,7 @@ wt/
 │   │   ├── pr.ts             # wt pr
 │   │   ├── list.ts           # wt list / wt ls
 │   │   ├── remove.ts         # wt remove / wt rm
+│   │   ├── rename.ts         # wt rename
 │   │   ├── clean.ts          # wt clean
 │   │   ├── cd.ts             # wt cd
 │   │   ├── shell.ts          # wt shell install

--- a/docs/superpowers/specs/2026-04-26-worktree-rename-design.md
+++ b/docs/superpowers/specs/2026-04-26-worktree-rename-design.md
@@ -1,0 +1,25 @@
+# Worktree Rename Design
+
+## Goal
+
+Add `wt rename <new-id>` to change the current linked worktree's ID without moving the worktree directory.
+
+## Behavior
+
+- The command operates on the worktree containing the current working directory.
+- The main worktree cannot be renamed.
+- The new ID is trimmed and must not be empty.
+- The command fails if the new ID would conflict with any other worktree's `id` or `fullId`.
+- The command updates `.wt/meta.json`, preserving existing metadata such as base branch, base commit, creation time, and pull request fields.
+- The worktree directory path is not changed.
+
+## Architecture
+
+- Add an app-layer use case that resolves the repository context, loads worktrees, identifies the current linked worktree, validates the new ID, reads existing metadata, and writes updated metadata.
+- Add a command-layer wrapper for terminal output.
+- Register `rename <new-id>` in the CLI entrypoint.
+
+## Testing
+
+- Add e2e coverage proving `wt rename` changes `WT_ID`/list/cd behavior while preserving the original path.
+- Add e2e coverage proving rename rejects IDs already used by another worktree.

--- a/src/app/use-cases/rename-worktree.ts
+++ b/src/app/use-cases/rename-worktree.ts
@@ -1,0 +1,110 @@
+import { isPathInside } from "../../domain/path.js";
+import type { WorktreeInfo, WorktreeMeta } from "../../domain/worktree.js";
+import {
+  readWorktreeMeta,
+  writeWorktreeMeta,
+} from "../../infra/storage/worktree-meta-store.js";
+import { AppError } from "../errors.js";
+import { requireRepositoryContext } from "../repository-context.js";
+import { loadWorktreeInfos } from "../worktree-catalog.js";
+
+export interface RenameWorktreeResult {
+  oldId: string;
+  newId: string;
+  fullId: string;
+  worktreePath: string;
+}
+
+function normalizeWorktreeId(id: string): string {
+  const value = id.trim();
+
+  if (!value) {
+    throw new AppError("Worktree ID is required");
+  }
+
+  return value;
+}
+
+function findCurrentWorktree(
+  worktrees: WorktreeInfo[],
+  cwd: string
+): WorktreeInfo | undefined {
+  return worktrees
+    .filter((worktree) => isPathInside(worktree.path, cwd))
+    .sort((a, b) => b.path.length - a.path.length)[0];
+}
+
+function assertIdAvailable(
+  worktrees: WorktreeInfo[],
+  currentWorktree: WorktreeInfo,
+  newId: string,
+  newFullId: string
+): void {
+  const conflictingWorktree = worktrees.find((worktree) => {
+    if (worktree.path === currentWorktree.path) {
+      return false;
+    }
+
+    return (
+      worktree.id === newId ||
+      worktree.id === newFullId ||
+      worktree.fullId === newId ||
+      worktree.fullId === newFullId
+    );
+  });
+
+  if (conflictingWorktree) {
+    throw new AppError(`Worktree ID "${newId}" is already in use`);
+  }
+}
+
+function buildRenamedMeta(
+  worktree: WorktreeInfo,
+  meta: WorktreeMeta | undefined,
+  newId: string,
+  newFullId: string
+): WorktreeMeta {
+  return {
+    baseBranch: meta?.baseBranch ?? worktree.baseBranch ?? "",
+    baseCommit: meta?.baseCommit ?? worktree.baseCommit ?? "",
+    createdAt: meta?.createdAt ?? worktree.createdAt,
+    prNumber: meta?.prNumber ?? worktree.prNumber,
+    prUrl: meta?.prUrl ?? worktree.prUrl,
+    id: newId,
+    fullId: newFullId,
+  };
+}
+
+export async function renameCurrentWorktree(
+  newIdInput: string,
+  cwd: string = process.cwd()
+): Promise<RenameWorktreeResult> {
+  const newId = normalizeWorktreeId(newIdInput);
+  const context = await requireRepositoryContext(cwd);
+  const worktrees = await loadWorktreeInfos(context);
+  const currentWorktree = findCurrentWorktree(worktrees, context.cwd);
+
+  if (!currentWorktree) {
+    throw new AppError("Current directory is not inside a git worktree");
+  }
+
+  if (currentWorktree.isMain) {
+    throw new AppError("Cannot rename the main worktree");
+  }
+
+  const fullId = `${context.repoName}-${newId}`;
+  assertIdAvailable(worktrees, currentWorktree, newId, fullId);
+
+  const meta = await readWorktreeMeta(currentWorktree.path);
+  await writeWorktreeMeta(
+    currentWorktree.path,
+    buildRenamedMeta(currentWorktree, meta, newId, fullId)
+  );
+
+  return {
+    oldId: currentWorktree.id,
+    newId,
+    fullId,
+    worktreePath: currentWorktree.path,
+  };
+}

--- a/src/app/use-cases/rename-worktree.ts
+++ b/src/app/use-cases/rename-worktree.ts
@@ -64,9 +64,12 @@ function buildRenamedMeta(
   newId: string,
   newFullId: string
 ): WorktreeMeta {
+  const baseBranch = meta?.baseBranch ?? worktree.baseBranch;
+  const baseCommit = meta?.baseCommit ?? worktree.baseCommit;
+
   return {
-    baseBranch: meta?.baseBranch ?? worktree.baseBranch ?? "",
-    baseCommit: meta?.baseCommit ?? worktree.baseCommit ?? "",
+    ...(baseBranch ? { baseBranch } : {}),
+    ...(baseCommit ? { baseCommit } : {}),
     createdAt: meta?.createdAt ?? worktree.createdAt,
     prNumber: meta?.prNumber ?? worktree.prNumber,
     prUrl: meta?.prUrl ?? worktree.prUrl,

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -1553,6 +1553,26 @@ describe("cli e2e", () => {
     );
   });
 
+  test("does not persist an empty base branch when renaming a raw git worktree", async () => {
+    const repo = await createTestRepo();
+    const oldId = "raw-rename";
+    const newId = "raw-renamed";
+    const rawWorktreePath = getWorktreePath(repo, oldId);
+
+    await $`git -C ${repo.repoRoot} worktree add -b feature-raw-rename ${rawWorktreePath} main`.quiet();
+
+    const result = runCliCapture(["rename", newId], rawWorktreePath);
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+
+    const meta = JSON.parse(
+      readFileSync(join(rawWorktreePath, ".wt", "meta.json"), "utf-8")
+    );
+
+    expect(meta.id).toBe(newId);
+    expect(meta.fullId).toBe(`${repo.repoName}-${newId}`);
+    expect("baseBranch" in meta).toBeFalse();
+  });
+
   test("marks the main worktree in list output", async () => {
     const repo = await createTestRepo();
     const worktreeId = "mainmark123";

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -1573,6 +1573,34 @@ describe("cli e2e", () => {
     expect("baseBranch" in meta).toBeFalse();
   });
 
+  test("uses the main worktree name for full ids when renaming without an origin remote", async () => {
+    const repoRoot = makeTempDir("wt-no-origin-repo-");
+    const worktreeRoot = makeTempDir("wt-no-origin-worktrees-");
+    const repoName = basename(repoRoot);
+    const oldId = "old";
+    const newId = "new";
+    const worktreePath = join(worktreeRoot, `${repoName}-${oldId}`);
+
+    await $`git -C ${repoRoot} init`.quiet();
+    await $`git -C ${repoRoot} config user.email test@example.com`.quiet();
+    await $`git -C ${repoRoot} config user.name tester`.quiet();
+    await $`git -C ${repoRoot} checkout -b main`.quiet();
+    writeFileSync(join(repoRoot, "README.md"), "base\n");
+    await $`git -C ${repoRoot} add README.md`.quiet();
+    await $`git -C ${repoRoot} commit -m base`.quiet();
+    await $`git -C ${repoRoot} worktree add -b feature-no-origin ${worktreePath} main`.quiet();
+
+    const result = runCliCapture(["rename", newId], worktreePath);
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+
+    const meta = JSON.parse(
+      readFileSync(join(worktreePath, ".wt", "meta.json"), "utf-8")
+    );
+
+    expect(meta.id).toBe(newId);
+    expect(meta.fullId).toBe(`${repoName}-${newId}`);
+  });
+
   test("marks the main worktree in list output", async () => {
     const repo = await createTestRepo();
     const worktreeId = "mainmark123";

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -1479,6 +1479,80 @@ describe("cli e2e", () => {
     expect(existsSync(worktreePath)).toBeFalse();
   });
 
+  test("renames the current worktree id without moving the directory", async () => {
+    if (!isShellAvailable("bash")) {
+      return;
+    }
+
+    const repo = await createTestRepo();
+    const oldId = "rename-old";
+    const newId = "rename-new";
+    const branchName = "feature-rename";
+    const worktreePath = getWorktreePath(repo, oldId);
+
+    runCli(["new", branchName, "--id", oldId, "--no-cd"], repo.repoRoot);
+
+    const renameResult = runCliCapture(["rename", newId], worktreePath);
+    assertProcessSuccess(
+      renameResult.status,
+      renameResult.stderr,
+      renameResult.stdout
+    );
+
+    const meta = JSON.parse(
+      readFileSync(join(worktreePath, ".wt", "meta.json"), "utf-8")
+    );
+    const listResult = runCliCapture(["list"], repo.repoRoot);
+    assertProcessSuccess(listResult.status, listResult.stderr, listResult.stdout);
+    const idLines = listResult.stdout
+      .split(/\r?\n/)
+      .filter(line => line.startsWith("ID:"));
+    const cdResult = runWrappedBashSession(repo.repoRoot, [
+      `wt cd ${newId}`,
+      "cd_status=$?",
+      'cd_pwd="$PWD"',
+      'printf \'CD_STATUS=%s\\nCD_PWD=%s\\n\' "$cd_status" "$cd_pwd"',
+    ]);
+
+    assertProcessSuccess(cdResult.processStatus, cdResult.stderr, cdResult.stdout);
+
+    expect(renameResult.stdout).toContain(
+      `Renamed worktree: ${oldId} -> ${newId}`
+    );
+    expect(meta.id).toBe(newId);
+    expect(meta.fullId).toBe(`${repo.repoName}-${newId}`);
+    expect(existsSync(worktreePath)).toBeTrue();
+    expect(existsSync(getWorktreePath(repo, newId))).toBeFalse();
+    expect(idLines).toContain(`ID:      ${newId}`);
+    expect(idLines).not.toContain(`ID:      ${oldId}`);
+    expect(Number(readOutputValue(cdResult.stdout, "CD_STATUS"))).toBe(0);
+    expect(realpathSync(readOutputValue(cdResult.stdout, "CD_PWD"))).toBe(
+      realpathSync(worktreePath)
+    );
+  });
+
+  test("rejects renaming a worktree id to an id already in use", async () => {
+    const repo = await createTestRepo();
+    const oldId = "rename-conflict-old";
+    const occupiedId = "rename-conflict-new";
+
+    runCli(["new", "feature-rename-a", "--id", oldId, "--no-cd"], repo.repoRoot);
+    runCli(
+      ["new", "feature-rename-b", "--id", occupiedId, "--no-cd"],
+      repo.repoRoot
+    );
+
+    const result = runCliCapture(
+      ["rename", occupiedId],
+      getWorktreePath(repo, oldId)
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      `Worktree ID "${occupiedId}" is already in use`
+    );
+  });
+
   test("marks the main worktree in list output", async () => {
     const repo = await createTestRepo();
     const worktreeId = "mainmark123";

--- a/src/commands/rename.ts
+++ b/src/commands/rename.ts
@@ -1,0 +1,15 @@
+import chalk from "chalk";
+import { renameCurrentWorktree } from "../app/use-cases/rename-worktree.js";
+import { runCommand } from "../cli/command-runtime.js";
+
+export async function renameCommand(newId: string): Promise<void> {
+  await runCommand(async () => {
+    const result = await renameCurrentWorktree(newId);
+
+    console.log(
+      chalk.green(`✓ Renamed worktree: ${result.oldId} -> ${result.newId}`)
+    );
+    console.log(chalk.dim(`  WT_ID: ${result.newId}`));
+    console.log(chalk.dim(`  WT_PATH: ${result.worktreePath}`));
+  });
+}

--- a/src/domain/worktree.ts
+++ b/src/domain/worktree.ts
@@ -3,9 +3,9 @@ import { basename } from "path";
 export const DETACHED_WORKTREE_LABEL = "(detached)";
 
 export interface WorktreeMeta {
-  baseBranch: string;
-  baseCommit: string;
-  createdAt: string;
+  baseBranch?: string;
+  baseCommit?: string;
+  createdAt?: string;
   id?: string;
   fullId?: string;
   prNumber?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { initCommand } from "./commands/init.js";
 import { newCommand } from "./commands/new.js";
 import { listCommand } from "./commands/list.js";
 import { removeCommand } from "./commands/remove.js";
+import { renameCommand } from "./commands/rename.js";
 import { cleanCommand } from "./commands/clean.js";
 import { cdCommand } from "./commands/cd.js";
 import { updateCommand } from "./commands/update.js";
@@ -50,6 +51,11 @@ program
   .option("--keep-branch", "Keep the branch after removing worktree")
   .option("-f, --force", "Skip confirmation for worktrees with pending changes")
   .action(removeCommand);
+
+program
+  .command("rename <new-id>")
+  .description("Rename the current worktree ID without moving its directory")
+  .action(renameCommand);
 
 program
   .command("clean")

--- a/src/infra/git/repository.ts
+++ b/src/infra/git/repository.ts
@@ -30,5 +30,17 @@ export async function getRepoName(repoRoot: string): Promise<string> {
     }
   } catch {}
 
+  try {
+    const worktreeList =
+      await $`git -C ${repoRoot} worktree list --porcelain`.text();
+    const mainWorktreeLine = worktreeList
+      .split("\n")
+      .find((line) => line.startsWith("worktree "));
+
+    if (mainWorktreeLine) {
+      return basename(mainWorktreeLine.substring(9));
+    }
+  } catch {}
+
   return basename(repoRoot);
 }

--- a/src/infra/shell/installer.test.ts
+++ b/src/infra/shell/installer.test.ts
@@ -33,6 +33,7 @@ describe("shell installer", () => {
 
       expect(wrapper).toBe(renderShellWrapper("zsh", "/tmp/wt-bin"));
       expect(wrapper).toContain('clean[Bulk-remove worktrees interactively]');
+      expect(wrapper).toContain('rename[Rename the current worktree ID]');
     } finally {
       rmSync(shellDir, { recursive: true, force: true });
     }

--- a/src/infra/shell/installer.ts
+++ b/src/infra/shell/installer.ts
@@ -144,6 +144,7 @@ _wt_completion() {
         'ls[List all worktrees]' \\
         'remove[Remove a worktree]' \\
         'rm[Remove a worktree]' \\
+        'rename[Rename the current worktree ID]' \\
         'clean[Bulk-remove worktrees interactively]' \\
         'cd[Change directory to a worktree]' \\
         'pr[Create or navigate to a pull request worktree]' \\


### PR DESCRIPTION
## Summary
- Add `wt rename <new-id>` to rename the current linked worktree ID without moving its directory.
- Persist the new `id`/`fullId` in `.wt/meta.json` while preserving existing metadata and rejecting conflicts.
- Document the command and include it in zsh shell completion.

## Test Plan
- `bun run typecheck`
- `bun test`
- `bun run build`