### PR TITLE
Allow removing current worktree with dot

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -288,6 +288,7 @@ worktree에 수정된 파일이나 push되지 않은 커밋이 남아 있으면,
 - ID (기본값: 브랜치 이름, 예: `feature/issue-12`)
 - 레포 prefix가 포함된 전체 ID (예: `myrepo-feature/issue-12`)
 - worktree를 고유하게 식별할 수 있는 경로의 일부
+- `.`: 현재 디렉터리가 속한 worktree 제거
 
 ### 조건에 맞는 worktree 정리
 

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ You can remove a worktree using:
 - ID (defaults to the branch name, e.g., `feature/issue-12`)
 - Full ID with repo prefix (e.g., `myrepo-feature/issue-12`)
 - Any part of the path that uniquely identifies the worktree
+- `.` to remove the worktree containing your current directory
 
 ### Clean up matching worktrees
 

--- a/src/app/use-cases/remove-worktree.ts
+++ b/src/app/use-cases/remove-worktree.ts
@@ -56,6 +56,15 @@ function getErrorMessage(error: unknown): string {
   return String(error);
 }
 
+function findCurrentWorktree(
+  worktrees: WorktreeInfo[],
+  cwd: string
+): WorktreeInfo | undefined {
+  return worktrees
+    .filter((worktree) => isPathInside(worktree.path, cwd))
+    .sort((a, b) => b.path.length - a.path.length)[0];
+}
+
 async function resolveRemovalTarget(
   target: string,
   cwd: string
@@ -65,6 +74,20 @@ async function resolveRemovalTarget(
 }> {
   const context = await requireRepositoryContext(cwd);
   const worktrees = await loadWorktreeInfos(context);
+
+  if (target === ".") {
+    const currentWorktree = findCurrentWorktree(worktrees, context.cwd);
+
+    if (!currentWorktree) {
+      throw new AppError("Current directory is not inside a git worktree");
+    }
+
+    return {
+      context,
+      worktree: currentWorktree,
+    };
+  }
+
   const result = resolveWorktreeTarget(worktrees, target, {
     allowPartialPath: true,
   });

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -2026,6 +2026,40 @@ describe("cli e2e", () => {
   );
 
   test(
+    "removes the current worktree when target is dot",
+    async () => {
+      if (!isShellAvailable("bash")) {
+        return;
+      }
+
+      const repo = await createTestRepo();
+      const worktreeId = "rmdot123";
+      const branchName = "feature-rm-dot";
+      const worktreePath = getWorktreePath(repo, worktreeId);
+      const nestedDir = join(worktreePath, "nested");
+
+      runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
+      mkdirSync(nestedDir, { recursive: true });
+
+      const result = runWrappedBashSession(repo.repoRoot, [
+        `builtin cd "${nestedDir}"`,
+        "wt rm . --keep-branch",
+        "rm_status=$?",
+        'rm_pwd="$PWD"',
+        'printf \'RM_STATUS=%s\\nRM_PWD=%s\\n\' "$rm_status" "$rm_pwd"',
+      ]);
+
+      assertProcessSuccess(result.processStatus, result.stderr, result.stdout);
+
+      expect(Number(readOutputValue(result.stdout, "RM_STATUS"))).toBe(0);
+      expect(realpathSync(readOutputValue(result.stdout, "RM_PWD"))).toBe(
+        realpathSync(repo.repoRoot)
+      );
+      expect(existsSync(worktreePath)).toBeFalse();
+    }
+  );
+
+  test(
     "returns the shell to the main worktree after removing the current worktree in a batch that exits nonzero",
     async () => {
       if (!isShellAvailable("bash")) {


### PR DESCRIPTION
## Summary
- Resolve `wt rm .` to the worktree containing the current directory
- Reuse the existing safe current-worktree removal flow and shell relocation behavior
- Document the dot target in English and Korean READMEs

## Test Plan
- `bun test`
- `bun run typecheck`