### PR TITLE
Show issue tracker links in list output

### DIFF
--- a/.changeset/issue-links.md
+++ b/.changeset/issue-links.md
@@ -1,0 +1,5 @@
+---
+"@leesangb/wt": minor
+---
+
+Show configurable issue tracker links in wt list output

--- a/README.ko.md
+++ b/README.ko.md
@@ -318,10 +318,23 @@ wt clean -m -d --keep-branch
 - **scripts.pre**: worktree 생성 전에 실행할 명령어 배열 (저장소 루트에서 실행)
 - **scripts.post**: worktree 생성 후에 실행할 명령어 배열 (새 worktree 디렉토리에서 실행)
 - **scripts.postMode**: `async`(기본값) 또는 `sync`(포그라운드 실행)
+- **issue.pattern**: 브랜치 이름에서 이슈 키를 추출할 선택적 JavaScript 정규식
+- **issue.url**: 선택적 이슈 트래커 URL 템플릿. 추출한 키가 들어갈 위치에 `$issue`를 사용합니다
 
-사용자별 또는 머신별 override가 필요하면 선택적으로 `.wt/settings.local.json`도 둘 수 있습니다. `wt`는 먼저 `.wt/settings.json`을 읽고, 그 위에 `.wt/settings.local.json`을 덮어씁니다. 중첩된 `copy.*`와 `scripts.*` 필드도 병합되므로 `copy.exclude`나 `scripts.postMode`만 따로 바꿀 수 있습니다.
+사용자별 또는 머신별 override가 필요하면 선택적으로 `.wt/settings.local.json`도 둘 수 있습니다. `wt`는 먼저 `.wt/settings.json`을 읽고, 그 위에 `.wt/settings.local.json`을 덮어씁니다. 중첩된 `copy.*`, `scripts.*`, `issue.*` 필드도 병합되므로 `copy.exclude`, `scripts.postMode`, `issue.url`만 따로 바꿀 수 있습니다.
 
 `copy.include`와 `copy.exclude`는 저장소 루트를 기준으로 해석됩니다. 앞에 `./`를 붙여도 되고, `./apps`와 `apps`는 같은 의미입니다. `.wt`나 `apps/web`처럼 디렉토리 이름만 적으면 `/**`를 붙인 것처럼 하위 전체에 적용됩니다. `wt`는 source 저장소에서 git에 트래킹되지 않은 파일만 복사하고, 새로 만든 worktree 쪽에서 이미 tracked인 파일은 덮어쓰지 않습니다. 또한 항상 `.git`, `node_modules`, 그리고 현재 `.gitignore`에 의해 무시되는 디렉토리를 건너뜁니다. `.wt/meta.json`, `.wt/.gitignore`, async post-task 상태 파일처럼 `wt`가 내부적으로 쓰는 예약 파일은 계속 `wt`가 관리합니다.
+
+`issue`를 설정하면 `wt list` / `wt ls`가 각 브랜치 이름에 `issue.pattern`을 매칭합니다. 정규식에 캡처 그룹이 있으면 첫 번째 그룹을 이슈 키로 쓰고, 없으면 전체 매치를 사용합니다. 지원되는 터미널에서는 출력된 URL을 바로 클릭할 수 있습니다:
+
+```json
+{
+  "issue": {
+    "pattern": "[A-Z]+-\\d+",
+    "url": "https://myissues.com/$issue"
+  }
+}
+```
 
 예시 `.wt/settings.local.json`:
 

--- a/README.md
+++ b/README.md
@@ -318,10 +318,23 @@ Edit `.wt/settings.json` in your repository:
 - **scripts.pre**: Array of commands to run before creating worktree (runs in repo root)
 - **scripts.post**: Array of commands to run after creating worktree (runs in new worktree directory)
 - **scripts.postMode**: `async` (default) or `sync` for foreground execution
+- **issue.pattern**: Optional JavaScript regular expression for extracting issue keys from branch names
+- **issue.url**: Optional issue tracker URL template. Use `$issue` where the extracted key should appear
 
-You can also add an optional `.wt/settings.local.json` for user- or machine-local overrides. `wt` loads `.wt/settings.json` first, then applies `.wt/settings.local.json` on top of it. Nested `copy.*` and `scripts.*` fields are merged, so you can override only `copy.exclude` or `scripts.postMode` without copying the rest of each object.
+You can also add an optional `.wt/settings.local.json` for user- or machine-local overrides. `wt` loads `.wt/settings.json` first, then applies `.wt/settings.local.json` on top of it. Nested `copy.*`, `scripts.*`, and `issue.*` fields are merged, so you can override only `copy.exclude`, `scripts.postMode`, or `issue.url` without copying the rest of each object.
 
 `copy.include` and `copy.exclude` are resolved relative to the repository root. A leading `./` is optional, so `./apps` and `apps` mean the same thing. If a pattern names a directory without `/**` (for example `.wt` or `apps/web`), `wt` treats it as the whole subtree for both include and exclude rules. `wt` only copies files that are untracked in the source repo, and it will not overwrite files already tracked in the newly created worktree. It always skips `.git`, `node_modules`, and directories currently ignored by `.gitignore`. Internal reserved files under `.wt/` such as `meta.json`, `.gitignore`, and async post-task state remain managed by `wt`.
+
+When `issue` is configured, `wt list` / `wt ls` matches `issue.pattern` against each branch name. If the pattern has a capture group, the first group becomes the issue key; otherwise the full match is used. The URL is printed as a clickable terminal link where supported:
+
+```json
+{
+  "issue": {
+    "pattern": "[A-Z]+-\\d+",
+    "url": "https://myissues.com/$issue"
+  }
+}
+```
 
 Example `.wt/settings.local.json`:
 

--- a/src/app/use-cases/list-worktrees.ts
+++ b/src/app/use-cases/list-worktrees.ts
@@ -4,12 +4,16 @@ import type {
   WorktreeState,
 } from "../../domain/worktree.js";
 import { requireRepositoryContext } from "../repository-context.js";
+import { AppError } from "../errors.js";
+import { buildIssueLinkFromPattern } from "../../domain/issue-link.js";
 import { listPullRequestLinks } from "../../infra/github/cli.js";
+import { loadSettings } from "../../infra/storage/settings-store.js";
 import {
   loadWorktreeInfos,
   loadWorktreeRemovalInfos,
   loadWorktreeStates,
 } from "../worktree-catalog.js";
+import type { WtIssueSettings } from "../../domain/settings.js";
 
 export interface ListWorktreeInfosOptions {
   excludeMainWorktree?: boolean;
@@ -63,6 +67,44 @@ async function enrichWorktreesWithPullRequests<T extends WorktreeInfo>(
   });
 }
 
+function enrichWorktreesWithIssueLinks<T extends WorktreeInfo>(
+  issueSettings: WtIssueSettings | undefined,
+  worktrees: T[]
+): T[] {
+  if (!issueSettings) {
+    return worktrees;
+  }
+
+  let issuePattern: RegExp;
+
+  try {
+    issuePattern = new RegExp(issueSettings.pattern);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new AppError(
+      `Invalid issue.pattern "${issueSettings.pattern}": ${message}`
+    );
+  }
+
+  return worktrees.map((worktree) => {
+    const issueLink = buildIssueLinkFromPattern(
+      worktree.branch,
+      issuePattern,
+      issueSettings.url
+    );
+
+    if (!issueLink) {
+      return worktree;
+    }
+
+    return {
+      ...worktree,
+      issueKey: issueLink.key,
+      issueUrl: issueLink.url,
+    };
+  });
+}
+
 export async function listWorktreeInfos(
   cwd: string = process.cwd(),
   options: ListWorktreeInfosOptions = {}
@@ -83,9 +125,14 @@ export async function listWorktrees(
   cwd: string = process.cwd()
 ): Promise<ListWorktreesResult> {
   const context = await requireRepositoryContext(cwd);
+  const settings = await loadSettings(context.repoRoot);
+  const worktreesWithIssueLinks = enrichWorktreesWithIssueLinks(
+    settings.issue,
+    await loadWorktreeStates(context)
+  );
   const worktrees = await enrichWorktreesWithPullRequests(
     context.repoRoot,
-    await loadWorktreeStates(context)
+    worktreesWithIssueLinks
   );
 
   return {

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -1649,6 +1649,43 @@ describe("cli e2e", () => {
     expect(ghLog).not.toContain(`pr view ${branchName}`);
   });
 
+  test("shows an issue tracker URL in list output for matching branch names", async () => {
+    const repo = await createTestRepo();
+    const branchName = "feature/DEV-123";
+
+    updateSettings(repo.repoRoot, settings => {
+      settings.issue = {
+        pattern: "[A-Z]+-\\d+",
+        url: "https://myissues.com/$issue",
+      };
+    });
+    runCli(["new", branchName, "--no-cd"], repo.repoRoot);
+
+    const result = runCliCapture(["ls"], repo.repoRoot);
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+
+    expect(result.stdout).toContain("Issue:   DEV-123 https://myissues.com/DEV-123");
+  });
+
+  test("shows an actionable error for invalid issue tracker patterns", async () => {
+    const repo = await createTestRepo();
+    const branchName = "feature/DEV-123";
+
+    updateSettings(repo.repoRoot, settings => {
+      settings.issue = {
+        pattern: "[A-Z+",
+        url: "https://myissues.com/$issue",
+      };
+    });
+    runCli(["new", branchName, "--no-cd"], repo.repoRoot);
+
+    const result = runCliCapture(["ls"], repo.repoRoot);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Invalid issue.pattern");
+    expect(result.stderr).toContain("[A-Z+");
+  });
+
   test("shows stored pull request URLs in list output for PR worktrees", async () => {
     const repo = await createTestRepo();
     const prNumber = "789";

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -25,6 +25,7 @@ export async function initCommand(): Promise<void> {
     console.log(chalk.dim("  - scripts.pre: Array of commands to run before creating worktree"));
     console.log(chalk.dim("  - scripts.post: Array of commands to run after creating worktree"));
     console.log(chalk.dim("  - scripts.postMode: 'sync' | 'async' (default: async)"));
+    console.log(chalk.dim("  - issue.pattern / issue.url: Optional issue links for wt list"));
     console.log(chalk.dim("  - optional local overrides: .wt/settings.local.json"));
   });
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -88,12 +88,16 @@ export async function listCommand(options?: {
     for (const worktree of result.worktrees) {
       const idLabel = buildWorktreeIdLabel(worktree);
       const pullRequestSummary = buildPullRequestSummary(worktree);
+      const issueSummary = buildIssueSummary(worktree);
       const timestamp = new Date(worktree.createdAt).toLocaleString();
 
       console.log(chalk.cyan(`ID:      ${idLabel}`));
       console.log(
         chalk.white(`Branch:  ${buildWorktreeBranchSummary(worktree)}`)
       );
+      if (issueSummary) {
+        console.log(`Issue:   ${issueSummary}`);
+      }
       if (pullRequestSummary) {
         console.log(`PR:      ${pullRequestSummary}`);
       }
@@ -148,4 +152,16 @@ function buildPullRequestSummary(
   return worktree.prNumber
     ? `#${worktree.prNumber} ${worktree.prUrl}`
     : worktree.prUrl;
+}
+
+function buildIssueSummary(
+  worktree: Pick<WorktreeState, "issueKey" | "issueUrl">
+): string | undefined {
+  if (!worktree.issueUrl) {
+    return undefined;
+  }
+
+  return worktree.issueKey
+    ? `${worktree.issueKey} ${worktree.issueUrl}`
+    : worktree.issueUrl;
 }

--- a/src/domain/issue-link.test.ts
+++ b/src/domain/issue-link.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { buildIssueLink } from "./issue-link.js";
+
+describe("buildIssueLink", () => {
+  test("builds an issue URL from a branch name using the full match", () => {
+    expect(
+      buildIssueLink("feature/DEV-123", {
+        pattern: "[A-Z]+-\\d+",
+        url: "https://myissues.com/$issue",
+      })
+    ).toEqual({
+      key: "DEV-123",
+      url: "https://myissues.com/DEV-123",
+    });
+  });
+
+  test("uses the first capture group as the issue key", () => {
+    expect(
+      buildIssueLink("feature/DEV-123-extra", {
+        pattern: "feature/([A-Z]+-\\d+)",
+        url: "https://myissues.com/browse/$issue",
+      })
+    ).toEqual({
+      key: "DEV-123",
+      url: "https://myissues.com/browse/DEV-123",
+    });
+  });
+
+  test("returns undefined when the branch does not match the issue pattern", () => {
+    expect(
+      buildIssueLink("feature/no-ticket", {
+        pattern: "[A-Z]+-\\d+",
+        url: "https://myissues.com/$issue",
+      })
+    ).toBeUndefined();
+  });
+});

--- a/src/domain/issue-link.ts
+++ b/src/domain/issue-link.ts
@@ -1,0 +1,48 @@
+import type { WtIssueSettings } from "./settings.js";
+
+export interface IssueLink {
+  key: string;
+  url: string;
+}
+
+export function buildIssueLink(
+  branch: string | undefined,
+  settings: WtIssueSettings | undefined
+): IssueLink | undefined {
+  if (!branch || !settings) {
+    return undefined;
+  }
+
+  return buildIssueLinkFromPattern(
+    branch,
+    new RegExp(settings.pattern),
+    settings.url
+  );
+}
+
+export function buildIssueLinkFromPattern(
+  branch: string | undefined,
+  pattern: RegExp,
+  urlTemplate: string
+): IssueLink | undefined {
+  if (!branch) {
+    return undefined;
+  }
+
+  const match = pattern.exec(branch);
+
+  if (!match) {
+    return undefined;
+  }
+
+  const issueKey = match[1] ?? match[0];
+
+  if (!issueKey) {
+    return undefined;
+  }
+
+  return {
+    key: issueKey,
+    url: urlTemplate.replaceAll("$issue", encodeURIComponent(issueKey)),
+  };
+}

--- a/src/domain/settings.test.ts
+++ b/src/domain/settings.test.ts
@@ -47,6 +47,29 @@ describe("mergeSettingsInputs", () => {
       },
     });
   });
+
+  test("merges nested issue overrides without dropping sibling fields", () => {
+    expect(
+      mergeSettingsInputs(
+        {
+          issue: {
+            pattern: "[A-Z]+-\\d+",
+            url: "https://old.example/$issue",
+          },
+        },
+        {
+          issue: {
+            url: "https://new.example/$issue",
+          },
+        }
+      )
+    ).toEqual({
+      issue: {
+        pattern: "[A-Z]+-\\d+",
+        url: "https://new.example/$issue",
+      },
+    });
+  });
 });
 
 describe("normalizeSettings", () => {
@@ -99,6 +122,20 @@ describe("normalizeSettings", () => {
         post: [],
         postMode: "async",
       },
+    });
+  });
+
+  test("preserves issue tracker settings", () => {
+    expect(
+      normalizeSettings({
+        issue: {
+          pattern: "[A-Z]+-\\d+",
+          url: "https://myissues.com/$issue",
+        },
+      }).issue
+    ).toEqual({
+      pattern: "[A-Z]+-\\d+",
+      url: "https://myissues.com/$issue",
     });
   });
 

--- a/src/domain/settings.ts
+++ b/src/domain/settings.ts
@@ -11,19 +11,28 @@ export interface WtCopySettings {
   exclude: string[];
 }
 
+export interface WtIssueSettings {
+  pattern: string;
+  url: string;
+}
+
 export interface WtSettings {
   worktreeDir: string;
   baseBranch: string;
   pushRemote: boolean;
   copy: WtCopySettings;
   scripts: WtScriptsSettings;
+  issue?: WtIssueSettings;
 }
 
 export type WtCopySettingsInput = string[] | Partial<WtCopySettings>;
 
-export type WtSettingsInput = Partial<Omit<WtSettings, "copy" | "scripts">> & {
+export type WtSettingsInput = Partial<
+  Omit<WtSettings, "copy" | "scripts" | "issue">
+> & {
   copy?: WtCopySettingsInput;
   scripts?: Partial<WtScriptsSettings>;
+  issue?: Partial<WtIssueSettings>;
 };
 
 export const DEFAULT_WT_SETTINGS: WtSettings = {
@@ -57,6 +66,19 @@ function normalizeCopyInput(
   return input;
 }
 
+function normalizeIssueInput(
+  input?: Partial<WtIssueSettings> | null
+): WtIssueSettings | undefined {
+  if (!input?.pattern || !input.url) {
+    return undefined;
+  }
+
+  return {
+    pattern: input.pattern,
+    url: input.url,
+  };
+}
+
 export function mergeSettingsInputs(
   base?: WtSettingsInput | null,
   override?: WtSettingsInput | null
@@ -81,12 +103,20 @@ export function mergeSettingsInputs(
           ...overrideCopy,
         }
       : undefined;
+  const mergedIssue =
+    base?.issue || override?.issue
+      ? {
+          ...base?.issue,
+          ...override?.issue,
+        }
+      : undefined;
 
   return {
     ...base,
     ...override,
     ...(mergedCopy ? { copy: mergedCopy } : {}),
     ...(mergedScripts ? { scripts: mergedScripts } : {}),
+    ...(mergedIssue ? { issue: mergedIssue } : {}),
   };
 }
 
@@ -94,6 +124,7 @@ export function normalizeSettings(
   input?: WtSettingsInput | null
 ): WtSettings {
   const copyInput = normalizeCopyInput(input?.copy);
+  const issueInput = normalizeIssueInput(input?.issue);
 
   return {
     worktreeDir: input?.worktreeDir ?? DEFAULT_WT_SETTINGS.worktreeDir,
@@ -109,5 +140,6 @@ export function normalizeSettings(
       postMode:
         input?.scripts?.postMode ?? DEFAULT_WT_SETTINGS.scripts.postMode,
     },
+    ...(issueInput ? { issue: issueInput } : {}),
   };
 }

--- a/src/domain/worktree.ts
+++ b/src/domain/worktree.ts
@@ -34,6 +34,8 @@ export interface WorktreeInfo {
   baseCommit?: string;
   prNumber?: string;
   prUrl?: string;
+  issueKey?: string;
+  issueUrl?: string;
 }
 
 export interface WorktreeState extends WorktreeInfo {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export type {
+  WtIssueSettings,
   ScriptMode,
   WtSettings,
   WtSettingsInput,


### PR DESCRIPTION
## Summary
- Add optional `issue.pattern` / `issue.url` settings for extracting issue keys from branch names.
- Show matching issue tracker URLs in `wt list` / `wt ls` output.
- Document the setting in English/Korean READMEs and add a changeset.

## Test Plan
- `rtk bun run typecheck`
- `rtk bun test --timeout 30000`
- `rtk bun run build`