### PR TITLE
fix: refresh shell wrappers after update

### DIFF
--- a/src/app/use-cases/update-installation.test.ts
+++ b/src/app/use-cases/update-installation.test.ts
@@ -17,6 +17,7 @@ describe("update installation use case", () => {
   test("delegates Homebrew installs through the app layer", async () => {
     const delegatedCommands: string[] = [];
     const executedPlans: Array<{ args: string[]; displayCommand: string }> = [];
+    const refreshedBinaries: string[] = [];
 
     const result = await updateInstallation("0.3.0", {}, {
       processInfo: {
@@ -25,11 +26,22 @@ describe("update installation use case", () => {
       },
       onBeforeHomebrewUpdate: (command) => delegatedCommands.push(command),
       runHomebrewUpdate: (plan) => executedPlans.push(plan),
+      refreshShellWrappers: (binaryPath) => {
+        refreshedBinaries.push(binaryPath);
+        return {
+          refreshedShells: ["zsh"],
+          warnings: [],
+        };
+      },
     });
 
     expect(result).toEqual({
       strategy: "homebrew",
       delegatedCommand: "brew upgrade wt",
+      shellIntegration: {
+        refreshedShells: ["zsh"],
+        warnings: [],
+      },
     });
     expect(delegatedCommands).toEqual(["brew upgrade wt"]);
     expect(executedPlans).toEqual([
@@ -38,5 +50,66 @@ describe("update installation use case", () => {
         displayCommand: "brew upgrade wt",
       },
     ]);
+    expect(refreshedBinaries).toEqual(["/opt/homebrew/bin/wt"]);
+  });
+
+  test("refreshes existing shell wrappers after a standalone binary update", async () => {
+    const downloads: string[] = [];
+    const replacements: Array<{ tempPath: string; execPath: string }> = [];
+    const quarantines: string[] = [];
+    const refreshedBinaries: string[] = [];
+
+    const result = await updateInstallation(
+      "0.6.0",
+      { version: "0.6.1" },
+      {
+        arch: "arm64",
+        platform: "darwin",
+        processInfo: {
+          argv0: "wt",
+          execPath: "/Users/test/.local/bin/wt",
+        },
+        downloadBinary: async (url) => {
+          downloads.push(url);
+          return "/tmp/wt-new";
+        },
+        replaceCurrentBinary: (tempPath, execPath) => {
+          replacements.push({ tempPath, execPath });
+        },
+        removeMacosQuarantine: async (execPath) => {
+          quarantines.push(execPath);
+        },
+        refreshShellWrappers: (binaryPath) => {
+          refreshedBinaries.push(binaryPath);
+          return {
+            refreshedShells: ["bash", "zsh"],
+            warnings: [],
+          };
+        },
+      }
+    );
+
+    expect(downloads).toEqual([
+      "https://github.com/leesangb/wt/releases/download/v0.6.1/wt-macos-arm64",
+    ]);
+    expect(replacements).toEqual([
+      {
+        tempPath: "/tmp/wt-new",
+        execPath: "/Users/test/.local/bin/wt",
+      },
+    ]);
+    expect(quarantines).toEqual(["/Users/test/.local/bin/wt"]);
+    expect(refreshedBinaries).toEqual(["/Users/test/.local/bin/wt"]);
+    expect(result).toEqual({
+      strategy: "standalone",
+      currentVersion: "0.6.0",
+      targetVersion: "0.6.1",
+      updated: true,
+      assetName: "wt-macos-arm64",
+      shellIntegration: {
+        refreshedShells: ["bash", "zsh"],
+        warnings: [],
+      },
+    });
   });
 });

--- a/src/app/use-cases/update-installation.ts
+++ b/src/app/use-cases/update-installation.ts
@@ -1,8 +1,13 @@
 import { AppError } from "../errors.js";
+import { basename, resolve } from "path";
 import {
-  downloadBinary,
-  removeMacosQuarantine,
-  replaceCurrentBinary,
+  refreshExistingShellWrappers,
+  type RefreshShellWrappersResult,
+} from "../../infra/shell/installer.js";
+import {
+  downloadBinary as defaultDownloadBinary,
+  removeMacosQuarantine as defaultRemoveMacosQuarantine,
+  replaceCurrentBinary as defaultReplaceCurrentBinary,
 } from "../../infra/update/binary-installer.js";
 import {
   fetchLatestRelease,
@@ -12,11 +17,15 @@ import {
 import {
   buildHomebrewUpdatePlan,
   isHomebrewManagedInstallation,
+  resolveHomebrewShellBinaryPath,
   runHomebrewUpdate,
   type HomebrewProcessInfo,
   type HomebrewUpdatePlan,
 } from "../../infra/update/homebrew.js";
 import { compareVersions } from "../../infra/update/version.js";
+
+const BINARY_NAME = "wt";
+const RUNTIME_LAUNCHERS = new Set(["bun", "node"]);
 
 export interface UpdateInstallationOptions {
   force?: boolean;
@@ -30,11 +39,13 @@ export interface StandaloneUpdateInstallationResult {
   targetVersion?: string;
   updated: boolean;
   assetName?: string;
+  shellIntegration?: RefreshShellWrappersResult;
 }
 
 export interface HomebrewDelegatedUpdateResult {
   strategy: "homebrew";
   delegatedCommand: string;
+  shellIntegration: RefreshShellWrappersResult;
 }
 
 export type UpdateInstallationResult =
@@ -45,7 +56,13 @@ export type UpdateStrategy = "standalone" | "homebrew";
 
 export interface UpdateInstallationContext {
   processInfo?: HomebrewProcessInfo;
+  platform?: NodeJS.Platform;
+  arch?: NodeJS.Architecture;
+  downloadBinary?: (url: string) => Promise<string>;
   onBeforeHomebrewUpdate?: (command: string) => void;
+  refreshShellWrappers?: (binaryPath: string) => RefreshShellWrappersResult;
+  removeMacosQuarantine?: (execPath: string) => Promise<void>;
+  replaceCurrentBinary?: (tempPath: string, execPath: string) => void;
   runHomebrewUpdate?: (plan: HomebrewUpdatePlan) => void;
 }
 
@@ -63,20 +80,84 @@ export function getUpdateStrategy(
   return isHomebrewManagedInstallation(processInfo) ? "homebrew" : "standalone";
 }
 
+function looksLikePath(value: string | undefined): value is string {
+  if (!value) {
+    return false;
+  }
+
+  return value.includes("/") || value.includes("\\");
+}
+
+function resolveCurrentStandaloneBinaryPath(
+  processInfo: HomebrewProcessInfo = {
+    argv0: process.argv0,
+    execPath: process.execPath,
+  }
+): string | undefined {
+  if (!processInfo.execPath) {
+    return undefined;
+  }
+
+  if (isHomebrewManagedInstallation(processInfo)) {
+    return undefined;
+  }
+
+  const execPath = resolve(processInfo.execPath);
+
+  if (basename(execPath).toLowerCase() === BINARY_NAME) {
+    return execPath;
+  }
+
+  const argv0 = processInfo.argv0 ?? "";
+  const launcherName = basename(argv0).toLowerCase();
+
+  if (
+    looksLikePath(argv0) &&
+    !RUNTIME_LAUNCHERS.has(launcherName) &&
+    basename(argv0).toLowerCase() === BINARY_NAME
+  ) {
+    return resolve(argv0);
+  }
+
+  return undefined;
+}
+
+function refreshShellWrappers(
+  binaryPath: string,
+  context: UpdateInstallationContext
+): RefreshShellWrappersResult {
+  return (
+    context.refreshShellWrappers ??
+    ((path) => refreshExistingShellWrappers({ binaryPath: path }))
+  )(binaryPath);
+}
+
 async function updateStandaloneInstallation(
   currentVersion: string,
-  options: UpdateInstallationOptions
+  options: UpdateInstallationOptions,
+  context: UpdateInstallationContext
 ): Promise<StandaloneUpdateInstallationResult> {
-  if (process.platform !== "darwin") {
+  const platform = context.platform ?? process.platform;
+  const arch = context.arch ?? process.arch;
+
+  if (platform !== "darwin") {
     throw new AppError(
       "Update command currently supports only macOS (darwin)."
     );
   }
 
-  const assetName = getSupportedMacosAssetName(process.arch);
+  const binaryPath = resolveCurrentStandaloneBinaryPath(context.processInfo);
+
+  if (!binaryPath) {
+    throw new AppError(
+      "Could not determine the standalone wt binary to update. If you are running from a source checkout, use `./install.sh --force` or install a release binary first."
+    );
+  }
+
+  const assetName = getSupportedMacosAssetName(arch);
 
   if (!assetName) {
-    throw new AppError(`Unsupported architecture: ${process.arch}`);
+    throw new AppError(`Unsupported architecture: ${arch}`);
   }
 
   let targetVersion = options.version?.replace(/^v/, "");
@@ -127,13 +208,21 @@ async function updateStandaloneInstallation(
     downloadUrl = getReleaseAssetDownloadUrl(targetVersion, assetName);
   }
 
-  const tempPath = await downloadBinary(downloadUrl);
-  const execPath = process.execPath;
-  replaceCurrentBinary(tempPath, execPath);
+  const tempPath = await (context.downloadBinary ?? defaultDownloadBinary)(
+    downloadUrl
+  );
+  (context.replaceCurrentBinary ?? defaultReplaceCurrentBinary)(
+    tempPath,
+    binaryPath
+  );
 
   if (options.removeQuarantine !== false) {
-    await removeMacosQuarantine(execPath);
+    await (context.removeMacosQuarantine ?? defaultRemoveMacosQuarantine)(
+      binaryPath
+    );
   }
+
+  const shellIntegration = refreshShellWrappers(binaryPath, context);
 
   return {
     strategy: "standalone",
@@ -141,6 +230,7 @@ async function updateStandaloneInstallation(
     targetVersion,
     updated: true,
     assetName,
+    shellIntegration,
   };
 }
 
@@ -156,12 +246,17 @@ export async function updateInstallation(
 
     context.onBeforeHomebrewUpdate?.(plan.displayCommand);
     (context.runHomebrewUpdate ?? runHomebrewUpdate)(plan);
+    const shellIntegration = refreshShellWrappers(
+      resolveHomebrewShellBinaryPath(context.processInfo),
+      context
+    );
 
     return {
       strategy: "homebrew",
       delegatedCommand: plan.displayCommand,
+      shellIntegration,
     };
   }
 
-  return updateStandaloneInstallation(currentVersion, options);
+  return updateStandaloneInstallation(currentVersion, options, context);
 }

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -471,7 +471,7 @@ describe("cli e2e", () => {
 
     assertProcessSuccess(result.status, result.stderr, result.stdout);
     expect(readFileSync(wrapperPath, "utf-8")).toBe(
-      renderShellWrapper("bash", binaryPath)
+      renderShellWrapper("bash", binaryPath, { wrapperPath })
     );
     expect(result.stdout).toContain("~/.wt/shell/wt.bash");
     expect(result.stdout).toContain(appendCommand);

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -5,6 +5,7 @@ import {
   getUpdateStrategy,
   updateInstallation,
   type UpdateInstallationOptions,
+  type UpdateInstallationResult,
 } from "../app/use-cases/update-installation.js";
 
 function buildUpdateSpinnerText(options: UpdateInstallationOptions): string {
@@ -17,6 +18,26 @@ function buildUpdateSpinnerText(options: UpdateInstallationOptions): string {
   return "Checking for wt updates";
 }
 
+function printShellIntegrationRefresh(result: UpdateInstallationResult): void {
+  const shellIntegration = result.shellIntegration;
+
+  if (!shellIntegration) {
+    return;
+  }
+
+  if (shellIntegration.refreshedShells.length > 0) {
+    console.log(
+      chalk.dim(
+        `Refreshed shell integration for ${shellIntegration.refreshedShells.join(", ")}.`
+      )
+    );
+  }
+
+  for (const warning of shellIntegration.warnings) {
+    console.log(chalk.yellow(`Warning: ${warning}`));
+  }
+}
+
 export async function updateCommand(
   options: UpdateInstallationOptions
 ): Promise<void> {
@@ -26,13 +47,14 @@ export async function updateCommand(
     const strategy = getUpdateStrategy();
 
     if (strategy === "homebrew") {
-      await updateInstallation(currentVersion, options, {
+      const result = await updateInstallation(currentVersion, options, {
         onBeforeHomebrewUpdate: (command) => {
           console.log(
             chalk.dim(`Homebrew installation detected. Running: ${command}`)
           );
         },
       });
+      printShellIntegrationRefresh(result);
       return;
     }
 
@@ -64,6 +86,7 @@ export async function updateCommand(
     }
 
     console.log(chalk.green(`✓ Updated wt to version ${result.targetVersion}`));
+    printShellIntegrationRefresh(result);
     console.log(chalk.dim("Run: wt --version to verify."));
   });
 }

--- a/src/infra/shell/installer.test.ts
+++ b/src/infra/shell/installer.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
   getShellSourceLine,
   getShellWrapperPath,
   installShellWrapper,
+  refreshExistingShellWrappers,
   renderShellWrapper,
 } from "./installer.js";
 
@@ -31,9 +32,55 @@ describe("shell installer", () => {
       expect(result.sourceLine).toBe(getShellSourceLine("zsh", shellDir));
       const wrapper = readFileSync(result.wrapperPath, "utf-8");
 
-      expect(wrapper).toBe(renderShellWrapper("zsh", "/tmp/wt-bin"));
+      expect(wrapper).toBe(
+        renderShellWrapper("zsh", "/tmp/wt-bin", {
+          wrapperPath: result.wrapperPath,
+        })
+      );
       expect(wrapper).toContain('clean[Bulk-remove worktrees interactively]');
       expect(wrapper).toContain('rename[Rename the current worktree ID]');
+    } finally {
+      rmSync(shellDir, { recursive: true, force: true });
+    }
+  });
+
+  test("installed wrappers reload themselves after a successful update", () => {
+    const shellDir = mkdtempSync(join(tmpdir(), "wt-shell-reload-"));
+
+    try {
+      const result = installShellWrapper({
+        shell: "zsh",
+        command: "/tmp/wt-bin",
+        shellDir,
+      });
+      const wrapper = readFileSync(result.wrapperPath, "utf-8");
+
+      expect(wrapper).toContain('__wt_wrapper_path="');
+      expect(wrapper).toContain('if [ "${1:-}" = "update" ] && [ $exit_code -eq 0 ]');
+      expect(wrapper).toContain('source "$__wt_wrapper_path"');
+    } finally {
+      rmSync(shellDir, { recursive: true, force: true });
+    }
+  });
+
+  test("permission errors include an ownership repair hint instead of implying sudo install", () => {
+    const shellDir = mkdtempSync(join(tmpdir(), "wt-shell-permission-"));
+    const error = new Error("permission denied") as NodeJS.ErrnoException;
+    error.code = "EACCES";
+
+    try {
+      expect(() =>
+        installShellWrapper({
+          shell: "bash",
+          command: "/tmp/wt-bin",
+          shellDir,
+          writeFile: () => {
+            throw error;
+          },
+        })
+      ).toThrow(
+        `Could not write wt shell integration in ${shellDir}. This usually means the directory is owned by another user. Run: sudo chown -R "$(id -u):$(id -g)" ~/.wt`
+      );
     } finally {
       rmSync(shellDir, { recursive: true, force: true });
     }
@@ -45,5 +92,44 @@ describe("shell installer", () => {
     expect(wrapper).toContain('function __wt_complete_cd');
     expect(wrapper).toContain('"/tmp/wt bin" list --completion fish 2>/dev/null');
     expect(wrapper).toContain('complete -c wt -n "__fish_seen_subcommand_from cd" -a "(__wt_complete_cd)" -f');
+  });
+
+  test("refreshes only shell wrappers that are already installed", () => {
+    const shellDir = mkdtempSync(join(tmpdir(), "wt-shell-refresh-"));
+    const calls: Array<{ command: string; args: string[] }> = [];
+
+    try {
+      writeFileSync(join(shellDir, "wt.zsh"), "# zsh wrapper\n");
+      writeFileSync(join(shellDir, "wt.fish"), "# fish wrapper\n");
+
+      const result = refreshExistingShellWrappers({
+        binaryPath: "/tmp/wt-bin",
+        shellDir,
+        runCommand: (command, args) => {
+          calls.push({ command, args });
+          return {
+            status: 0,
+            signal: null,
+          };
+        },
+      });
+
+      expect(result).toEqual({
+        refreshedShells: ["zsh", "fish"],
+        warnings: [],
+      });
+      expect(calls).toEqual([
+        {
+          command: "/tmp/wt-bin",
+          args: ["shell", "install", "zsh", "--binary-path", "/tmp/wt-bin"],
+        },
+        {
+          command: "/tmp/wt-bin",
+          args: ["shell", "install", "fish", "--binary-path", "/tmp/wt-bin"],
+        },
+      ]);
+    } finally {
+      rmSync(shellDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/infra/shell/installer.ts
+++ b/src/infra/shell/installer.ts
@@ -1,17 +1,50 @@
-import { mkdirSync, writeFileSync } from "fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { homedir } from "os";
 import { join } from "path";
-import type { SupportedShell } from "../../domain/shell.js";
+import { AppError } from "../../app/errors.js";
+import { SUPPORTED_SHELLS, type SupportedShell } from "../../domain/shell.js";
 
 export interface InstallShellWrapperOptions {
   shell: SupportedShell;
   command: string | readonly string[];
   shellDir: string;
+  mkdir?: typeof mkdirSync;
+  writeFile?: typeof writeFileSync;
 }
 
 export interface InstallShellWrapperResult {
   shell: SupportedShell;
   wrapperPath: string;
   sourceLine: string;
+}
+
+export interface RefreshShellWrappersResult {
+  refreshedShells: SupportedShell[];
+  warnings: string[];
+}
+
+export interface ShellCommandResult {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  error?: Error;
+  stderr?: string;
+  stdout?: string;
+}
+
+export type ShellCommandRunner = (
+  command: string,
+  args: string[],
+  options: {
+    encoding: "utf-8";
+    stdio: "pipe";
+  }
+) => ShellCommandResult;
+
+export interface RefreshExistingShellWrappersOptions {
+  binaryPath: string;
+  shellDir?: string;
+  runCommand?: ShellCommandRunner;
 }
 
 function escapeDoubleQuotedShell(value: string): string {
@@ -34,6 +67,48 @@ function renderShellCommand(command: string | readonly string[]): string {
     .join(" ");
 }
 
+function isPermissionError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+
+  return code === "EACCES" || code === "EPERM";
+}
+
+function throwShellWriteError(error: unknown, shellDir: string): never {
+  if (isPermissionError(error)) {
+    throw new AppError(
+      `Could not write wt shell integration in ${shellDir}. This usually means the directory is owned by another user. Run: sudo chown -R "$(id -u):$(id -g)" ~/.wt`
+    );
+  }
+
+  throw error;
+}
+
+function renderPosixReloadAfterUpdate(wrapperPath?: string): string {
+  if (!wrapperPath) {
+    return "";
+  }
+
+  return `
+  local __wt_wrapper_path="${escapeDoubleQuotedShell(wrapperPath)}"
+  if [ "\${1:-}" = "update" ] && [ $exit_code -eq 0 ] && [ -r "$__wt_wrapper_path" ]; then
+    source "$__wt_wrapper_path"
+  fi
+`;
+}
+
+function renderFishReloadAfterUpdate(wrapperPath?: string): string {
+  if (!wrapperPath) {
+    return "";
+  }
+
+  return `
+    set -l __wt_wrapper_path "${escapeDoubleQuotedShell(wrapperPath)}"
+    if test (count $argv) -gt 0; and test "$argv[1]" = update; and test $exit_code -eq 0; and test -r "$__wt_wrapper_path"
+        source "$__wt_wrapper_path"
+    end
+`;
+}
+
 export function getShellWrapperFileName(shell: SupportedShell): string {
   return `wt.${shell}`;
 }
@@ -53,8 +128,12 @@ export function getShellSourceLine(
   return `source "${escapeDoubleQuotedShell(wrapperPath)}"`;
 }
 
-function renderBashWrapper(command: string | readonly string[]): string {
+function renderBashWrapper(
+  command: string | readonly string[],
+  wrapperPath?: string
+): string {
   const renderedCommand = renderShellCommand(command);
+  const reloadAfterUpdate = renderPosixReloadAfterUpdate(wrapperPath);
 
   return `# wt shell wrapper for bash
 # Add this to your ~/.bashrc
@@ -75,6 +154,7 @@ wt() {
   fi
 
   rm -f "$cd_file"
+${reloadAfterUpdate}
   return $exit_code
 }
 
@@ -101,8 +181,12 @@ complete -F _wt_completion wt
 `;
 }
 
-function renderZshWrapper(command: string | readonly string[]): string {
+function renderZshWrapper(
+  command: string | readonly string[],
+  wrapperPath?: string
+): string {
   const renderedCommand = renderShellCommand(command);
+  const reloadAfterUpdate = renderPosixReloadAfterUpdate(wrapperPath);
 
   return `# wt shell wrapper for zsh
 # Add this to your ~/.zshrc
@@ -123,6 +207,7 @@ wt() {
   fi
 
   rm -f "$cd_file"
+${reloadAfterUpdate}
   return $exit_code
 }
 
@@ -171,8 +256,12 @@ compdef _wt_completion wt
 `;
 }
 
-function renderFishWrapper(command: string | readonly string[]): string {
+function renderFishWrapper(
+  command: string | readonly string[],
+  wrapperPath?: string
+): string {
   const renderedCommand = renderShellCommand(command);
+  const reloadAfterUpdate = renderFishReloadAfterUpdate(wrapperPath);
 
   return `# wt shell wrapper for fish
 # Add this to your ~/.config/fish/config.fish
@@ -192,6 +281,7 @@ function wt
     end
 
     rm -f "$cd_file"
+${reloadAfterUpdate}
     return $exit_code
 end
 
@@ -210,33 +300,96 @@ complete -c wt -n "__fish_seen_subcommand_from rm remove" -a "(__wt_complete_rem
 
 export function renderShellWrapper(
   shell: SupportedShell,
-  command: string | readonly string[]
+  command: string | readonly string[],
+  options: { wrapperPath?: string } = {}
 ): string {
   switch (shell) {
     case "bash":
-      return renderBashWrapper(command);
+      return renderBashWrapper(command, options.wrapperPath);
     case "zsh":
-      return renderZshWrapper(command);
+      return renderZshWrapper(command, options.wrapperPath);
     case "fish":
-      return renderFishWrapper(command);
+      return renderFishWrapper(command, options.wrapperPath);
   }
 }
 
 export function installShellWrapper(
   options: InstallShellWrapperOptions
 ): InstallShellWrapperResult {
-  mkdirSync(options.shellDir, { recursive: true });
+  try {
+    (options.mkdir ?? mkdirSync)(options.shellDir, { recursive: true });
+  } catch (error) {
+    throwShellWriteError(error, options.shellDir);
+  }
 
   const wrapperPath = getShellWrapperPath(options.shell, options.shellDir);
-  writeFileSync(
-    wrapperPath,
-    renderShellWrapper(options.shell, options.command),
-    "utf-8"
-  );
+
+  try {
+    (options.writeFile ?? writeFileSync)(
+      wrapperPath,
+      renderShellWrapper(options.shell, options.command, { wrapperPath }),
+      "utf-8"
+    );
+  } catch (error) {
+    throwShellWriteError(error, options.shellDir);
+  }
 
   return {
     shell: options.shell,
     wrapperPath,
     sourceLine: getShellSourceLine(options.shell, options.shellDir),
+  };
+}
+
+export function refreshExistingShellWrappers(
+  options: RefreshExistingShellWrappersOptions
+): RefreshShellWrappersResult {
+  const shellDir = options.shellDir ?? join(homedir(), ".wt", "shell");
+  const runCommand =
+    options.runCommand ??
+    ((command, args, commandOptions) =>
+      spawnSync(command, args, commandOptions));
+  const refreshedShells: SupportedShell[] = [];
+  const warnings: string[] = [];
+
+  for (const shell of SUPPORTED_SHELLS) {
+    const wrapperPath = getShellWrapperPath(shell, shellDir);
+
+    if (!existsSync(wrapperPath)) {
+      continue;
+    }
+
+    const result = runCommand(
+      options.binaryPath,
+      ["shell", "install", shell, "--binary-path", options.binaryPath],
+      {
+        encoding: "utf-8",
+        stdio: "pipe",
+      }
+    );
+
+    if (result.error) {
+      warnings.push(
+        `Could not refresh ${shell} shell wrapper at ${wrapperPath}: ${result.error.message}`
+      );
+      continue;
+    }
+
+    if (result.status !== 0) {
+      const stderr = result.stderr?.trim();
+      warnings.push(
+        `Could not refresh ${shell} shell wrapper at ${wrapperPath}: ${
+          stderr || `shell install exited with status ${result.status}`
+        }`
+      );
+      continue;
+    }
+
+    refreshedShells.push(shell);
+  }
+
+  return {
+    refreshedShells,
+    warnings,
   };
 }

--- a/src/infra/update/homebrew.ts
+++ b/src/infra/update/homebrew.ts
@@ -79,13 +79,24 @@ function isHomebrewLinkedBinPath(normalizedPath: string): boolean {
   );
 }
 
+function getHomebrewPrefixForManagedPath(
+  normalizedPath: string
+): string | undefined {
+  return HOMEBREW_PREFIXES.find((prefix) => {
+    return (
+      normalizedPath.startsWith(`${prefix}/Cellar/wt/`) ||
+      normalizedPath.startsWith(`${prefix}/opt/wt/`)
+    );
+  });
+}
+
 function isHomebrewExecutablePath(
   path: string,
   resolvePath: (path: string) => string | undefined = defaultResolvePath
 ): boolean {
   const normalizedPath = normalizeExecutablePath(path);
 
-  if (isHomebrewManagedTargetPath(normalizedPath)) {
+  if (getHomebrewPrefixForManagedPath(normalizedPath)) {
     return true;
   }
 
@@ -113,6 +124,34 @@ export function isHomebrewManagedInstallation(
   return candidates.some((candidate) =>
     isHomebrewExecutablePath(candidate, resolvePath)
   );
+}
+
+export function resolveHomebrewShellBinaryPath(
+  processInfo: HomebrewProcessInfo = {
+    argv0: process.argv0,
+    execPath: process.execPath,
+  }
+): string {
+  const candidates = [
+    looksLikePath(processInfo.argv0) ? processInfo.argv0 : undefined,
+    processInfo.execPath,
+  ].filter((value): value is string => Boolean(value));
+
+  for (const candidate of candidates) {
+    const normalizedPath = normalizeExecutablePath(candidate);
+
+    if (isHomebrewLinkedBinPath(normalizedPath)) {
+      return normalizedPath;
+    }
+
+    const prefix = getHomebrewPrefixForManagedPath(normalizedPath);
+
+    if (prefix) {
+      return `${prefix}/bin/wt`;
+    }
+  }
+
+  return "wt";
 }
 
 export function buildHomebrewUpdatePlan(


### PR DESCRIPTION
## Summary
- Refresh existing bash/zsh/fish shell wrappers after successful standalone or Homebrew updates.
- Re-source the installed wrapper after a successful \✓ Updated wt to version 0.6.0
Run: wt --version to verify. so the current shell picks up the refreshed command path.
- Resolve stable Homebrew shell binary paths and improve shell wrapper write error messaging.

## Test Plan
- [x] bun test
- [x] bun run typecheck