### PR TITLE
[codex] Background current worktree removal

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -284,6 +284,8 @@ wt rm <id...>
 
 worktree에 수정된 파일이나 push되지 않은 커밋이 남아 있으면, `wt rm`은 삭제 전에 한 번 더 확인합니다. 여러 worktree를 넘기면 각 대상마다 개별로 확인합니다. 프롬프트를 건너뛰려면 `wt rm <id...> --force`를 사용할 수 있습니다.
 
+현재 디렉터리가 속한 worktree를 제거할 때는 `wt rm`이 삭제 작업을 백그라운드로 시작하고, shell은 즉시 main worktree로 돌아갑니다. 출력에는 백그라운드 작업 PID와 main worktree의 `.wt/` 아래에 생성된 status/log 파일 경로가 표시됩니다. macOS에서는 백그라운드 삭제 성공 또는 실패를 알림으로 알려줍니다. 삭제가 끝날 때까지 기다리고 싶으면 `wt rm . --foreground`를 사용하세요.
+
 다음 방법으로 worktree를 제거할 수 있습니다:
 - ID (기본값: 브랜치 이름, 예: `feature/issue-12`)
 - 레포 prefix가 포함된 전체 ID (예: `myrepo-feature/issue-12`)

--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ wt rm <id...>
 
 If the worktree has modified files or unpushed commits, `wt rm` asks for confirmation before deleting it. When you pass multiple worktrees, it prompts separately for each one. Use `wt rm <id...> --force` to skip the prompts.
 
+When removing the worktree that contains your current directory, `wt rm` starts the removal in the background and immediately returns your shell to the main worktree. It prints the background task PID plus status and log file paths under the main worktree's `.wt/` directory. On macOS, Notification Center reports whether the background removal finished or failed. Use `wt rm . --foreground` if you want to wait for removal before returning.
+
 You can remove a worktree using:
 - ID (defaults to the branch name, e.g., `feature/issue-12`)
 - Full ID with repo prefix (e.g., `myrepo-feature/issue-12`)

--- a/src/app/use-cases/remove-worktree.ts
+++ b/src/app/use-cases/remove-worktree.ts
@@ -1,3 +1,4 @@
+import { join } from "path";
 import { AppError } from "../errors.js";
 import { isPathInside } from "../../domain/path.js";
 import { resolveWorktreeTarget } from "../../domain/worktree-target.js";
@@ -12,6 +13,11 @@ import {
   getWorktreeRemovalStatusSummary,
   getWorktreeStatusEntries,
 } from "../../infra/git/status.js";
+import {
+  executeDetachedTask,
+  shellEscapeSingle,
+} from "../../infra/scripts/runner.js";
+import { ensureRemoveTaskArtifactsIgnored } from "../../infra/storage/settings-store.js";
 import type { WorktreeInfo } from "../../domain/worktree.js";
 
 export interface RemoveWorktreeOptions {
@@ -20,6 +26,7 @@ export interface RemoveWorktreeOptions {
 
 export interface RemoveWorktreePreview {
   worktree: WorktreeInfo;
+  isCurrent: boolean;
   localCommitCount: number;
   localChangeCount: number;
   hasUnknownLocalCommits: boolean;
@@ -36,6 +43,15 @@ export interface RemoveWorktreeResult {
   worktree: WorktreeInfo;
   branchDeleted: boolean;
   relocatedToPath?: string;
+}
+
+export interface BackgroundRemoveWorktreeResult {
+  worktree: WorktreeInfo;
+  branchDeleteQueued: boolean;
+  relocatedToPath: string;
+  pid: number;
+  statusFilePath: string;
+  logFilePath: string;
 }
 
 export class RemoveWorktreeError extends AppError {
@@ -105,7 +121,7 @@ async function resolveRemovalTarget(
   };
 }
 
-async function resolveSafeRemovalRoot(
+async function findSafeRemovalRoot(
   context: Awaited<ReturnType<typeof requireRepositoryContext>>,
   worktree: WorktreeInfo
 ): Promise<{
@@ -120,18 +136,104 @@ async function resolveSafeRemovalRoot(
 
   const worktrees = await listGitWorktreePaths(context.repoRoot);
   const safeWorktree =
-    worktrees.find((candidate) => candidate.isMain && candidate.path !== worktree.path) ??
+    worktrees.find(
+      (candidate) => candidate.isMain && candidate.path !== worktree.path
+    ) ??
     worktrees.find((candidate) => candidate.path !== worktree.path);
 
   if (!safeWorktree) {
-    throw new AppError("Could not find another worktree to remove this worktree safely");
+    throw new AppError(
+      "Could not find another worktree to remove this worktree safely"
+    );
   }
-
-  process.chdir(safeWorktree.path);
 
   return {
     gitRoot: safeWorktree.path,
     relocatedToPath: safeWorktree.path,
+  };
+}
+
+async function resolveSafeRemovalRoot(
+  context: Awaited<ReturnType<typeof requireRepositoryContext>>,
+  worktree: WorktreeInfo
+): Promise<{
+  gitRoot: string;
+  relocatedToPath?: string;
+}> {
+  const removalRoot = await findSafeRemovalRoot(context, worktree);
+
+  if (removalRoot.relocatedToPath) {
+    process.chdir(removalRoot.relocatedToPath);
+  }
+
+  return removalRoot;
+}
+
+function normalizeTaskPathSegment(value: string): string {
+  return (
+    value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") ||
+    "worktree"
+  );
+}
+
+function buildRemovalTaskPaths(
+  safeWorktreePath: string,
+  worktree: WorktreeInfo
+): {
+  statusFilePath: string;
+  logFilePath: string;
+} {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const taskName = `remove-task-${normalizeTaskPathSegment(worktree.id)}-${timestamp}`;
+  const wtDir = join(safeWorktreePath, ".wt");
+
+  return {
+    statusFilePath: join(wtDir, `${taskName}.json`),
+    logFilePath: join(wtDir, `${taskName}.log`),
+  };
+}
+
+function buildRemovalTaskScripts(
+  removalRoot: string,
+  worktree: WorktreeInfo,
+  options: RemoveWorktreeOptions
+): string[] {
+  const scripts = [
+    `printf '%s\n' 'Removing worktree ${shellEscapeSingle(worktree.path)}'`,
+    [
+      `git -C '${shellEscapeSingle(removalRoot)}' worktree remove`,
+      `'${shellEscapeSingle(worktree.path)}' --force`,
+    ].join(" "),
+  ];
+
+  if (!options.keepBranch && worktree.branch) {
+    scripts.push(
+      `printf '%s\n' 'Deleting branch ${shellEscapeSingle(worktree.branch)}'`,
+      [
+        `git -C '${shellEscapeSingle(removalRoot)}' branch -D --`,
+        `'${shellEscapeSingle(worktree.branch)}'`,
+      ].join(" ")
+    );
+  }
+
+  return scripts;
+}
+
+function buildRemovalStartNotification(worktree: WorktreeInfo) {
+  return {
+    title: "wt",
+    message: `${worktree.id} removal started`,
+    subtitle: "Worktree removal running",
+  };
+}
+
+function buildRemovalCompletionNotification(worktree: WorktreeInfo) {
+  return {
+    title: "wt",
+    successMessage: `${worktree.id} removal finished`,
+    successSubtitle: "Worktree removed - log saved",
+    failureMessage: `${worktree.id} removal failed`,
+    failureSubtitle: "Check removal log",
   };
 }
 
@@ -160,6 +262,7 @@ export async function inspectRemoveWorktree(
 
   return {
     worktree,
+    isCurrent: isPathInside(worktree.path, context.cwd),
     localCommitCount,
     localChangeCount,
     hasUnknownLocalCommits,
@@ -214,5 +317,73 @@ export async function removeWorktree(
     worktree,
     branchDeleted: true,
     relocatedToPath: removalRoot.relocatedToPath,
+  };
+}
+
+export async function removeCurrentWorktreeInBackground(
+  target: string,
+  options: RemoveWorktreeOptions,
+  cwd: string = process.cwd()
+): Promise<BackgroundRemoveWorktreeResult> {
+  const { context, worktree } = await resolveRemovalTarget(target, cwd);
+
+  if (!isPathInside(worktree.path, context.cwd)) {
+    throw new AppError(
+      "Background removal is only available for the current worktree"
+    );
+  }
+
+  const removalRoot = await findSafeRemovalRoot(context, worktree);
+
+  if (!removalRoot.relocatedToPath) {
+    throw new AppError(
+      "Could not find another worktree to remove this worktree safely"
+    );
+  }
+
+  await ensureRemoveTaskArtifactsIgnored(removalRoot.relocatedToPath);
+
+  const { statusFilePath, logFilePath } = buildRemovalTaskPaths(
+    removalRoot.relocatedToPath,
+    worktree
+  );
+  const scripts = buildRemovalTaskScripts(
+    removalRoot.gitRoot,
+    worktree,
+    options
+  );
+  const pid = executeDetachedTask({
+    scripts,
+    cwd: removalRoot.gitRoot,
+    env: {
+      WT_ID: worktree.id,
+      WT_PATH: worktree.path,
+      ...(worktree.branch ? { WT_BRANCH: worktree.branch } : {}),
+    },
+    statusFilePath,
+    logFilePath,
+    statusMetadata: {
+      kind: "remove-worktree",
+      worktreeId: worktree.id,
+      worktreePath: worktree.path,
+      branch: worktree.branch,
+    },
+    startNotification:
+      process.platform === "darwin"
+        ? buildRemovalStartNotification(worktree)
+        : undefined,
+    completionNotification:
+      process.platform === "darwin"
+        ? buildRemovalCompletionNotification(worktree)
+        : undefined,
+  });
+
+  return {
+    worktree,
+    branchDeleteQueued: Boolean(worktree.branch && !options.keepBranch),
+    relocatedToPath: removalRoot.relocatedToPath,
+    pid,
+    statusFilePath,
+    logFilePath,
   };
 }

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -4,6 +4,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -389,6 +390,49 @@ function runWrappedBashSession(
 
 function readLines(path: string): string[] {
   return readFileSync(path, "utf-8").trimEnd().split(/\r?\n/);
+}
+
+function findRemoveTaskFiles(repoRoot: string, worktreeId: string): string[] {
+  const wtDir = join(repoRoot, ".wt");
+  const taskId = worktreeId
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "worktree";
+
+  if (!existsSync(wtDir)) {
+    return [];
+  }
+
+  return readdirSync(wtDir)
+    .filter(
+      (name) =>
+        name.startsWith(`remove-task-${taskId}-`) && name.endsWith(".json")
+    )
+    .map((name) => join(wtDir, name));
+}
+
+async function waitForRemoveTaskStatus(
+  repoRoot: string,
+  worktreeId: string,
+  expectedStatus: string
+): Promise<string> {
+  let foundStatusFilePath = "";
+
+  await waitFor(() => {
+    const statusFilePath = findRemoveTaskFiles(repoRoot, worktreeId)[0];
+
+    if (!statusFilePath) {
+      return false;
+    }
+
+    const status = JSON.parse(readFileSync(statusFilePath, "utf-8")) as {
+      status: string;
+    };
+
+    foundStatusFilePath = statusFilePath;
+    return status.status === expectedStatus;
+  });
+
+  return foundStatusFilePath;
 }
 
 async function waitFor(
@@ -2058,7 +2102,40 @@ describe("cli e2e", () => {
       expect(realpathSync(readOutputValue(result.stdout, "RM_PWD"))).toBe(
         realpathSync(repo.repoRoot)
       );
+      expect(result.stdout).toContain("Started background removal");
+
+      const statusFilePath = await waitForRemoveTaskStatus(
+        repo.repoRoot,
+        worktreeId,
+        "done"
+      );
       expect(existsSync(worktreePath)).toBeFalse();
+      const status = JSON.parse(readFileSync(statusFilePath, "utf-8")) as {
+        kind: string;
+        logFilePath: string;
+        status: string;
+        worktreeId: string;
+        worktreePath: string;
+      };
+      const logFilePath = statusFilePath.replace(/\.json$/, ".log");
+      const log = readFileSync(logFilePath, "utf-8");
+      const gitStatus = spawnSync(
+        "git",
+        ["-C", repo.repoRoot, "status", "--short", "--", statusFilePath, logFilePath],
+        {
+          encoding: "utf-8",
+        }
+      );
+
+      assertProcessSuccess(gitStatus.status, gitStatus.stderr, gitStatus.stdout);
+      expect(gitStatus.stdout.trim()).toBe("");
+      expect(status.kind).toBe("remove-worktree");
+      expect(status.status).toBe("done");
+      expect(status.worktreeId).toBe(worktreeId);
+      expect(status.worktreePath).toContain(worktreeId);
+      expect(realpathSync(status.logFilePath)).toBe(realpathSync(logFilePath));
+      expect(log).toContain("Removing worktree");
+      expect(log).toContain(worktreeId);
     }
   );
 
@@ -2070,12 +2147,12 @@ describe("cli e2e", () => {
       }
 
       const repo = await createTestRepo();
-      const worktreeId = "rmdot123";
-      const branchName = "feature-rm-dot";
+      const branchName = "feature/rm-dot";
+      const worktreeId = branchName;
       const worktreePath = getWorktreePath(repo, worktreeId);
       const nestedDir = join(worktreePath, "nested");
 
-      runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
+      runCli(["new", branchName, "--no-cd"], repo.repoRoot);
       mkdirSync(nestedDir, { recursive: true });
 
       const result = runWrappedBashSession(repo.repoRoot, [
@@ -2092,9 +2169,79 @@ describe("cli e2e", () => {
       expect(realpathSync(readOutputValue(result.stdout, "RM_PWD"))).toBe(
         realpathSync(repo.repoRoot)
       );
+      expect(result.stdout).toContain("Started background removal");
+
+      await waitForRemoveTaskStatus(repo.repoRoot, worktreeId, "done");
       expect(existsSync(worktreePath)).toBeFalse();
     }
   );
+
+  test("sends macOS notifications when background removal finishes", async () => {
+    if (process.platform !== "darwin" || !isShellAvailable("bash")) {
+      return;
+    }
+
+    const repo = await createTestRepo();
+    const worktreeId = "rmnotify123";
+    const branchName = "feature-rm-notify";
+    const worktreePath = getWorktreePath(repo, worktreeId);
+    const nestedDir = join(worktreePath, "nested");
+    const fakeBinDir = makeTempDir("wt-fake-bin-");
+    const notificationLogPath = join(fakeBinDir, "osascript.log");
+    const fakeOsascriptPath = join(fakeBinDir, "osascript");
+
+    writeFileSync(
+      fakeOsascriptPath,
+      [
+        "#!/bin/sh",
+        'printf "%s\\n" "$*" >> "$WT_TEST_OSASCRIPT_LOG"',
+        "",
+      ].join("\n"),
+      { mode: 0o755 }
+    );
+
+    runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
+    mkdirSync(nestedDir, { recursive: true });
+
+    const result = runWrappedBashSession(
+      repo.repoRoot,
+      [
+        `builtin cd "${nestedDir}"`,
+        "wt rm . --keep-branch",
+        "rm_status=$?",
+        'rm_pwd="$PWD"',
+        'printf \'RM_STATUS=%s\\nRM_PWD=%s\\n\' "$rm_status" "$rm_pwd"',
+      ],
+      {
+        PATH: fakeBinDir,
+        WT_TEST_OSASCRIPT_LOG: notificationLogPath,
+      }
+    );
+
+    assertProcessSuccess(result.processStatus, result.stderr, result.stdout);
+    expect(Number(readOutputValue(result.stdout, "RM_STATUS"))).toBe(0);
+
+    await waitForRemoveTaskStatus(repo.repoRoot, worktreeId, "done");
+    await waitFor(() => {
+      if (!existsSync(notificationLogPath)) {
+        return false;
+      }
+
+      const notificationLog = readFileSync(notificationLogPath, "utf-8");
+
+      return (
+        notificationLog.includes(`${worktreeId} removal finished`) &&
+        (notificationLog.match(/display notification/g)?.length ?? 0) === 2
+      );
+    });
+
+    const notificationLog = readFileSync(notificationLogPath, "utf-8");
+
+    expect(notificationLog).toContain(`${worktreeId} removal started`);
+    expect(notificationLog).toContain('subtitle "Worktree removal running"');
+    expect(notificationLog).toContain(`${worktreeId} removal finished`);
+    expect(notificationLog).toContain('subtitle "Worktree removed - log saved"');
+  });
 
   test(
     "returns the shell to the main worktree after removing the current worktree in a batch that exits nonzero",
@@ -2131,7 +2278,7 @@ describe("cli e2e", () => {
   );
 
   test(
-    "returns the shell to the main worktree when branch deletion fails after removing the current worktree",
+    "returns nonzero in foreground mode when branch deletion fails after removing the current worktree",
     async () => {
       if (!isShellAvailable("bash")) {
         return;
@@ -2142,7 +2289,10 @@ describe("cli e2e", () => {
       const branchName = "feature-rm-branch-fail";
       const worktreePath = getWorktreePath(repo, worktreeId);
       const nestedDir = join(worktreePath, "nested");
-      const lockedWorktreePath = join(repo.worktreeRoot, `${repo.repoName}-branch-lock`);
+      const lockedWorktreePath = join(
+        repo.worktreeRoot,
+        `${repo.repoName}-branch-lock`
+      );
 
       runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
       await $`git -C ${repo.repoRoot} worktree add --force ${lockedWorktreePath} ${branchName}`.quiet();
@@ -2150,7 +2300,7 @@ describe("cli e2e", () => {
 
       const result = runWrappedBashSession(repo.repoRoot, [
         `builtin cd "${nestedDir}"`,
-        `wt rm ${worktreeId} >/dev/null 2>/dev/null`,
+        `wt rm ${worktreeId} --foreground >/dev/null 2>/dev/null`,
         "rm_status=$?",
         'rm_pwd="$PWD"',
         'printf \'RM_STATUS=%s\\nRM_PWD=%s\\n\' "$rm_status" "$rm_pwd"',
@@ -2198,9 +2348,47 @@ describe("cli e2e", () => {
       expect(realpathSync(readOutputValue(result.stdout, "RM_PWD"))).toBe(
         realpathSync(repo.repoRoot)
       );
+      expect(result.stdout).toContain("Started background removal");
+
+      await waitForRemoveTaskStatus(repo.repoRoot, worktreeId, "done");
       expect(existsSync(worktreePath)).toBeFalse();
     }
   );
+
+  test("does not background removal of the main worktree", async () => {
+    if (!isShellAvailable("bash")) {
+      return;
+    }
+
+    const repo = await createTestRepo();
+    const linkedWorktreeId = "linked123";
+    const linkedBranchName = "feature-linked-worktree";
+    const linkedWorktreePath = getWorktreePath(repo, linkedWorktreeId);
+
+    runCli(
+      ["new", linkedBranchName, "--id", linkedWorktreeId, "--no-cd"],
+      repo.repoRoot
+    );
+
+    const result = runWrappedBashSession(repo.repoRoot, [
+      "wt rm . --keep-branch >/tmp/wt-rm-main-stdout 2>/tmp/wt-rm-main-stderr",
+      "rm_status=$?",
+      'rm_pwd="$PWD"',
+      'printf \'RM_STATUS=%s\\nRM_PWD=%s\\n\' "$rm_status" "$rm_pwd"',
+      "cat /tmp/wt-rm-main-stdout",
+    ]);
+
+    assertProcessSuccess(result.processStatus, result.stderr, result.stdout);
+
+    expect(Number(readOutputValue(result.stdout, "RM_STATUS"))).toBe(1);
+    expect(realpathSync(readOutputValue(result.stdout, "RM_PWD"))).toBe(
+      realpathSync(repo.repoRoot)
+    );
+    expect(result.stdout).not.toContain("Started background removal");
+    expect(existsSync(repo.repoRoot)).toBeTrue();
+    expect(existsSync(linkedWorktreePath)).toBeTrue();
+    expect(findRemoveTaskFiles(repo.repoRoot, repo.repoName)).toEqual([]);
+  });
 
   test("removes multiple worktrees in one command", async () => {
     const repo = await createTestRepo();

--- a/src/commands/remove-shared.ts
+++ b/src/commands/remove-shared.ts
@@ -3,7 +3,9 @@ import { createInterface } from "readline/promises";
 import { AppError } from "../app/errors.js";
 import { getWorktreeBranchLabel } from "../domain/worktree.js";
 import {
+  type BackgroundRemoveWorktreeResult,
   inspectRemoveWorktree,
+  removeCurrentWorktreeInBackground,
   RemoveWorktreeError,
   removeWorktree,
 } from "../app/use-cases/remove-worktree.js";
@@ -13,6 +15,7 @@ import { emitShellCd } from "../infra/shell/cd.js";
 export interface RemoveCommandOptions {
   keepBranch?: boolean;
   force?: boolean;
+  foreground?: boolean;
 }
 
 export interface RemovalPrompter {
@@ -223,6 +226,33 @@ export function logRemovalResult(
   }
 }
 
+export function logBackgroundRemovalResult(
+  result: BackgroundRemoveWorktreeResult
+): void {
+  const branchLabel = getWorktreeBranchLabel(result.worktree);
+
+  console.log(
+    chalk.blue(
+      `Started background removal: ${branchLabel} (${result.worktree.id})`
+    )
+  );
+  console.log(chalk.dim(`  PID: ${result.pid}`));
+  console.log(chalk.dim(`  Status: ${result.statusFilePath}`));
+  console.log(chalk.dim(`  Log: ${result.logFilePath}`));
+
+  if (result.branchDeleteQueued && result.worktree.branch) {
+    console.log(
+      chalk.dim(`  Branch deletion queued: ${result.worktree.branch}`)
+    );
+  } else if (result.worktree.branch) {
+    console.log(chalk.yellow(`Branch kept: ${result.worktree.branch}`));
+  } else {
+    console.log(chalk.dim("Detached worktree had no branch to delete"));
+  }
+
+  emitShellCd(result.relocatedToPath);
+}
+
 export async function removeSingleWorktree(
   id: string,
   options: RemoveCommandOptions,
@@ -253,6 +283,17 @@ export async function removeSingleWorktree(
       );
       return "skipped";
     }
+  }
+
+  if (
+    preview.isCurrent &&
+    !preview.worktree.isMain &&
+    !batchMode &&
+    !options.foreground
+  ) {
+    const result = await removeCurrentWorktreeInBackground(id, options);
+    logBackgroundRemovalResult(result);
+    return "removed";
   }
 
   const result = await runWithSpinner(

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ program
   .description("Remove one or more worktrees by ID")
   .option("--keep-branch", "Keep the branch after removing worktree")
   .option("-f, --force", "Skip confirmation for worktrees with pending changes")
+  .option("--foreground", "Wait for current worktree removal to finish")
   .action(removeCommand);
 
 program

--- a/src/infra/scripts/runner.ts
+++ b/src/infra/scripts/runner.ts
@@ -1,5 +1,5 @@
 import { spawn as spawnChildProcess } from "node:child_process";
-import { mkdirSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname } from "path";
 import { SHELL_CD_FILE_ENV } from "../shell/cd.js";
 
@@ -9,6 +9,12 @@ export interface DetachedScriptOptions {
   scripts: string[];
   startNotification?: DetachedNotification;
   completionNotification?: DetachedCompletionNotification;
+}
+
+export interface DetachedTaskOptions extends DetachedScriptOptions {
+  cwd: string;
+  env?: Record<string, string>;
+  statusMetadata?: Record<string, unknown>;
 }
 
 export interface DetachedNotification {
@@ -100,7 +106,12 @@ export function buildDetachedRunnerCommand(
     : undefined;
   const buildStatusUpdateCommand = (status: "done" | "failed"): string => [
     `tmp_status_file='${statusFile}'.tmp.$$`,
-    `printf '{"status":"${status}","finishedAt":"%s"}\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" > "$tmp_status_file"`,
+    `finished_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")`,
+    `if [ -f '${statusFile}' ]; then`,
+    `  sed -e 's/"status"[[:space:]]*:[[:space:]]*"running"/"status": "${status}"/' -e '$ s/}/,\\n  "finishedAt": "'"$finished_at"'"\\n}/' '${statusFile}' > "$tmp_status_file"`,
+    `else`,
+    `  printf '{"status":"${status}","finishedAt":"%s"}\n' "$finished_at" > "$tmp_status_file"`,
+    `fi`,
     `mv "$tmp_status_file" '${statusFile}'`,
   ].join("\n");
   const successCommands = [
@@ -178,8 +189,6 @@ export function executeScriptsDetached(
   statusFilePath: string,
   logFilePath: string
 ): number {
-  mkdirSync(dirname(statusFilePath), { recursive: true });
-  mkdirSync(dirname(logFilePath), { recursive: true });
   const target = env?.WT_BRANCH ?? env?.WT_ID ?? "Worktree";
   const startNotification =
     process.platform === "darwin"
@@ -190,10 +199,37 @@ export function executeScriptsDetached(
       ? buildPostScriptCompletionNotification(target)
       : undefined;
 
+  return executeDetachedTask({
+    scripts,
+    cwd,
+    env,
+    statusFilePath,
+    logFilePath,
+    startNotification,
+    completionNotification,
+  });
+}
+
+export function executeDetachedTask(options: DetachedTaskOptions): number {
+  const {
+    cwd,
+    env,
+    logFilePath,
+    scripts,
+    statusFilePath,
+    statusMetadata,
+    startNotification,
+    completionNotification,
+  } = options;
+
+  mkdirSync(dirname(statusFilePath), { recursive: true });
+  mkdirSync(dirname(logFilePath), { recursive: true });
+
   writeFileSync(
     statusFilePath,
     JSON.stringify(
       {
+        ...statusMetadata,
         status: "running",
         startedAt: new Date().toISOString(),
         logFilePath,
@@ -229,20 +265,30 @@ export function executeScriptsDetached(
   }
   proc.unref();
 
+  tryAddDetachedTaskPid(statusFilePath, pid);
+
+  return pid;
+}
+
+function tryAddDetachedTaskPid(statusFilePath: string, pid: number): void {
+  const status = JSON.parse(readFileSync(statusFilePath, "utf-8")) as {
+    status?: string;
+    [key: string]: unknown;
+  };
+
+  if (status.status !== "running") {
+    return;
+  }
+
   writeFileSync(
     statusFilePath,
     JSON.stringify(
       {
-        status: "running",
-        startedAt: new Date().toISOString(),
+        ...status,
         pid,
-        logFilePath,
-        scripts,
       },
       null,
       2
     )
   );
-
-  return pid;
 }

--- a/src/infra/storage/settings-store.test.ts
+++ b/src/infra/storage/settings-store.test.ts
@@ -10,8 +10,10 @@ import { tmpdir } from "os";
 import { join } from "path";
 import {
   ensureLocalSettingsIgnored,
+  ensureRemoveTaskArtifactsIgnored,
   loadSettings,
   LOCAL_SETTINGS_GITIGNORE_ENTRY,
+  REMOVE_TASK_GITIGNORE_ENTRIES,
 } from "./settings-store.js";
 
 const tempDirs: string[] = [];
@@ -55,6 +57,40 @@ describe("settings store", () => {
     await expect(ensureLocalSettingsIgnored(repoRoot)).resolves.toBe(false);
     expect(readFileSync(gitignorePath, "utf-8")).toBe(
       "settings.json\nsettings.local.json\n"
+    );
+  });
+
+  test("adds remove task artifact ignore entries", async () => {
+    const repoRoot = makeTempDir("wt-settings-store-");
+    const settingsDir = join(repoRoot, ".wt");
+
+    mkdirSync(settingsDir, { recursive: true });
+    writeFileSync(join(settingsDir, ".gitignore"), "settings.local.json\n");
+
+    await expect(ensureRemoveTaskArtifactsIgnored(repoRoot)).resolves.toBe(true);
+    expect(readFileSync(join(settingsDir, ".gitignore"), "utf-8")).toBe(
+      [
+        "settings.local.json",
+        ...REMOVE_TASK_GITIGNORE_ENTRIES,
+        "",
+      ].join("\n")
+    );
+  });
+
+  test("does not duplicate remove task artifact ignore entries", async () => {
+    const repoRoot = makeTempDir("wt-settings-store-");
+    const settingsDir = join(repoRoot, ".wt");
+    const gitignorePath = join(settingsDir, ".gitignore");
+
+    mkdirSync(settingsDir, { recursive: true });
+    writeFileSync(
+      gitignorePath,
+      ["settings.local.json", ...REMOVE_TASK_GITIGNORE_ENTRIES, ""].join("\n")
+    );
+
+    await expect(ensureRemoveTaskArtifactsIgnored(repoRoot)).resolves.toBe(false);
+    expect(readFileSync(gitignorePath, "utf-8")).toBe(
+      ["settings.local.json", ...REMOVE_TASK_GITIGNORE_ENTRIES, ""].join("\n")
     );
   });
 

--- a/src/infra/storage/settings-store.ts
+++ b/src/infra/storage/settings-store.ts
@@ -8,6 +8,10 @@ import {
 } from "../../domain/settings.js";
 
 export const LOCAL_SETTINGS_GITIGNORE_ENTRY = "settings.local.json";
+export const REMOVE_TASK_GITIGNORE_ENTRIES = [
+  "remove-task-*.json",
+  "remove-task-*.log",
+];
 const LOCAL_SETTINGS_GITIGNORE_ALIASES = new Set([
   LOCAL_SETTINGS_GITIGNORE_ENTRY,
   "/settings.local.json",
@@ -44,6 +48,19 @@ export async function loadSettings(repoRoot: string): Promise<WtSettings> {
 export async function ensureLocalSettingsIgnored(
   repoRoot: string
 ): Promise<boolean> {
+  return ensureWtGitignoreEntries(repoRoot, [LOCAL_SETTINGS_GITIGNORE_ENTRY]);
+}
+
+export async function ensureRemoveTaskArtifactsIgnored(
+  repoRoot: string
+): Promise<boolean> {
+  return ensureWtGitignoreEntries(repoRoot, REMOVE_TASK_GITIGNORE_ENTRIES);
+}
+
+async function ensureWtGitignoreEntries(
+  repoRoot: string,
+  entries: string[]
+): Promise<boolean> {
   const settingsDir = join(repoRoot, ".wt");
   const gitignorePath = join(settingsDir, ".gitignore");
 
@@ -54,11 +71,20 @@ export async function ensureLocalSettingsIgnored(
   const currentContent = existsSync(gitignorePath)
     ? readFileSync(gitignorePath, "utf-8")
     : "";
-  const alreadyIgnored = currentContent
+  const currentLines = currentContent
     .split(/\r?\n/)
-    .some((line) => LOCAL_SETTINGS_GITIGNORE_ALIASES.has(line.trim()));
+    .map((line) => line.trim());
+  const missingEntries = entries.filter((entry) => {
+    if (entry === LOCAL_SETTINGS_GITIGNORE_ENTRY) {
+      return !currentLines.some((line) =>
+        LOCAL_SETTINGS_GITIGNORE_ALIASES.has(line)
+      );
+    }
 
-  if (alreadyIgnored) {
+    return !currentLines.includes(entry);
+  });
+
+  if (missingEntries.length === 0) {
     return false;
   }
 
@@ -67,7 +93,7 @@ export async function ensureLocalSettingsIgnored(
 
   writeFileSync(
     gitignorePath,
-    `${currentContent}${separator}${LOCAL_SETTINGS_GITIGNORE_ENTRY}\n`,
+    `${currentContent}${separator}${missingEntries.join("\n")}\n`,
     "utf-8"
   );
 

--- a/src/utils/script.test.ts
+++ b/src/utils/script.test.ts
@@ -68,6 +68,8 @@ describe("buildDetachedRunnerCommand", () => {
     expect(cmd).toContain('"status":"done"');
     expect(cmd).toContain('"status":"failed"');
     expect(cmd).toContain("tmp_status_file='/tmp/post-task.json'.tmp.$$");
+    expect(cmd).toContain('"status": "done"');
+    expect(cmd).toContain('"finishedAt":');
     expect(cmd).toContain('mv "$tmp_status_file"');
   });
 

--- a/src/utils/script.ts
+++ b/src/utils/script.ts
@@ -4,6 +4,7 @@ export {
   buildPostScriptStartNotification,
   buildScriptEnv,
   escapeAppleScriptString,
+  executeDetachedTask,
   executeScript,
   executeScripts,
   executeScriptsDetached,
@@ -13,4 +14,5 @@ export type {
   DetachedNotification,
   DetachedCompletionNotification,
   DetachedScriptOptions,
+  DetachedTaskOptions,
 } from "../infra/scripts/runner.js";


### PR DESCRIPTION
## Summary

- Run single current-worktree removals in a detached background task after pending-work checks pass.
- Immediately return the shell to the main worktree and print PID/status/log paths for the removal task.
- Reuse the detached task runner for removal logs/status metadata and macOS start/completion/failure notifications.
- Add `--foreground` to preserve the old wait-for-removal behavior, plus README coverage in English and Korean.

## Why

Removing the worktree that contains the current shell can feel slow and awkward, even though the shell has to relocate before the directory disappears. This keeps the interactive shell moving while preserving visibility through status files, logs, and notifications.

## Validation

- `rtk bun run typecheck`
- `rtk bun test`
