### PR TITLE
[codex] Add current worktree command with PR lookup

### DIFF
--- a/src/app/repository-settings.ts
+++ b/src/app/repository-settings.ts
@@ -1,13 +1,20 @@
-import type { WtSettings } from "../domain/settings.js";
-import { listGitWorktreePaths } from "../infra/git/worktree-repository.js";
 import {
-  loadSettings,
-  settingsExist,
-} from "../infra/storage/settings-store.js";
+  mergeSettingsInputs,
+  normalizeSettings,
+  type WtSettings,
+  type WtSettingsInput,
+} from "../domain/settings.js";
+import { listGitWorktreePaths } from "../infra/git/worktree-repository.js";
+import { loadSettingsInputs } from "../infra/storage/settings-store.js";
 
 export interface RepositorySettings {
   settings: WtSettings;
-  settingsRoot: string;
+  worktreeDirRoot: string;
+}
+
+interface SettingsInputSource {
+  input?: WtSettingsInput;
+  root: string;
 }
 
 async function resolveMainWorktreePath(
@@ -17,31 +24,52 @@ async function resolveMainWorktreePath(
   return worktrees.find((worktree) => worktree.isMain)?.path;
 }
 
+function selectWorktreeDirRoot(
+  sources: SettingsInputSource[],
+  fallbackRoot: string
+): string {
+  return (
+    sources.find((source) => source.input?.worktreeDir !== undefined)?.root ??
+    fallbackRoot
+  );
+}
+
 export async function loadRepositorySettings(
   repoRoot: string
 ): Promise<RepositorySettings> {
-  if (await settingsExist(repoRoot)) {
-    return {
-      settings: await loadSettings(repoRoot),
-      settingsRoot: repoRoot,
-    };
-  }
-
   const mainWorktreePath = await resolveMainWorktreePath(repoRoot);
-
-  if (
-    mainWorktreePath &&
-    mainWorktreePath !== repoRoot &&
-    (await settingsExist(mainWorktreePath))
-  ) {
-    return {
-      settings: await loadSettings(mainWorktreePath),
-      settingsRoot: mainWorktreePath,
-    };
-  }
-
-  return {
-    settings: await loadSettings(repoRoot),
-    settingsRoot: repoRoot,
+  const settingsRoot = mainWorktreePath ?? repoRoot;
+  const currentInputs = await loadSettingsInputs(repoRoot);
+  const mainInputs =
+    settingsRoot === repoRoot
+      ? currentInputs
+      : await loadSettingsInputs(settingsRoot);
+  const sharedSource: SettingsInputSource = mainInputs.shared
+    ? { input: mainInputs.shared, root: settingsRoot }
+    : { input: currentInputs.shared, root: repoRoot };
+  const mainLocalSource: SettingsInputSource | undefined =
+    settingsRoot === repoRoot
+      ? undefined
+      : { input: mainInputs.local, root: settingsRoot };
+  const currentLocalSource: SettingsInputSource = {
+    input: currentInputs.local,
+    root: repoRoot,
   };
+  const localSettings = mergeSettingsInputs(
+    mainLocalSource?.input,
+    currentLocalSource.input
+  );
+  const settings = normalizeSettings(
+    mergeSettingsInputs(sharedSource.input, localSettings)
+  );
+  const worktreeDirRoot = selectWorktreeDirRoot(
+    [
+      currentLocalSource,
+      ...(mainLocalSource ? [mainLocalSource] : []),
+      sharedSource,
+    ],
+    sharedSource.root
+  );
+
+  return { settings, worktreeDirRoot };
 }

--- a/src/app/repository-settings.ts
+++ b/src/app/repository-settings.ts
@@ -5,6 +5,11 @@ import {
   settingsExist,
 } from "../infra/storage/settings-store.js";
 
+export interface RepositorySettings {
+  settings: WtSettings;
+  settingsRoot: string;
+}
+
 async function resolveMainWorktreePath(
   repoRoot: string
 ): Promise<string | undefined> {
@@ -14,9 +19,12 @@ async function resolveMainWorktreePath(
 
 export async function loadRepositorySettings(
   repoRoot: string
-): Promise<WtSettings> {
+): Promise<RepositorySettings> {
   if (await settingsExist(repoRoot)) {
-    return loadSettings(repoRoot);
+    return {
+      settings: await loadSettings(repoRoot),
+      settingsRoot: repoRoot,
+    };
   }
 
   const mainWorktreePath = await resolveMainWorktreePath(repoRoot);
@@ -26,8 +34,14 @@ export async function loadRepositorySettings(
     mainWorktreePath !== repoRoot &&
     (await settingsExist(mainWorktreePath))
   ) {
-    return loadSettings(mainWorktreePath);
+    return {
+      settings: await loadSettings(mainWorktreePath),
+      settingsRoot: mainWorktreePath,
+    };
   }
 
-  return loadSettings(repoRoot);
+  return {
+    settings: await loadSettings(repoRoot),
+    settingsRoot: repoRoot,
+  };
 }

--- a/src/app/repository-settings.ts
+++ b/src/app/repository-settings.ts
@@ -1,0 +1,33 @@
+import type { WtSettings } from "../domain/settings.js";
+import { listGitWorktreePaths } from "../infra/git/worktree-repository.js";
+import {
+  loadSettings,
+  settingsExist,
+} from "../infra/storage/settings-store.js";
+
+async function resolveMainWorktreePath(
+  repoRoot: string
+): Promise<string | undefined> {
+  const worktrees = await listGitWorktreePaths(repoRoot);
+  return worktrees.find((worktree) => worktree.isMain)?.path;
+}
+
+export async function loadRepositorySettings(
+  repoRoot: string
+): Promise<WtSettings> {
+  if (await settingsExist(repoRoot)) {
+    return loadSettings(repoRoot);
+  }
+
+  const mainWorktreePath = await resolveMainWorktreePath(repoRoot);
+
+  if (
+    mainWorktreePath &&
+    mainWorktreePath !== repoRoot &&
+    (await settingsExist(mainWorktreePath))
+  ) {
+    return loadSettings(mainWorktreePath);
+  }
+
+  return loadSettings(repoRoot);
+}

--- a/src/app/repository-settings.ts
+++ b/src/app/repository-settings.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "util";
 import {
   mergeSettingsInputs,
   normalizeSettings,
@@ -34,6 +35,21 @@ function selectWorktreeDirRoot(
   );
 }
 
+function selectSharedSettingsSource(
+  currentSource: SettingsInputSource,
+  mainSource: SettingsInputSource
+): SettingsInputSource {
+  if (!currentSource.input) {
+    return mainSource;
+  }
+
+  if (!mainSource.input || !isDeepStrictEqual(currentSource.input, mainSource.input)) {
+    return currentSource;
+  }
+
+  return mainSource;
+}
+
 export async function loadRepositorySettings(
   repoRoot: string
 ): Promise<RepositorySettings> {
@@ -44,9 +60,18 @@ export async function loadRepositorySettings(
     settingsRoot === repoRoot
       ? currentInputs
       : await loadSettingsInputs(settingsRoot);
-  const sharedSource: SettingsInputSource = mainInputs.shared
-    ? { input: mainInputs.shared, root: settingsRoot }
-    : { input: currentInputs.shared, root: repoRoot };
+  const currentSharedSource: SettingsInputSource = {
+    input: currentInputs.shared,
+    root: repoRoot,
+  };
+  const mainSharedSource: SettingsInputSource = {
+    input: mainInputs.shared,
+    root: settingsRoot,
+  };
+  const sharedSource = selectSharedSettingsSource(
+    currentSharedSource,
+    mainSharedSource
+  );
   const mainLocalSource: SettingsInputSource | undefined =
     settingsRoot === repoRoot
       ? undefined

--- a/src/app/use-cases/create-branch-worktree.ts
+++ b/src/app/use-cases/create-branch-worktree.ts
@@ -10,9 +10,9 @@ import {
 } from "../worktree-creation.js";
 import { copyConfiguredPaths } from "../worktree-copy.js";
 import { requireRepositoryContext } from "../repository-context.js";
+import { loadRepositorySettings } from "../repository-settings.js";
 import { loadWorktreeInfos } from "../worktree-catalog.js";
 import {
-  loadSettings,
   resolveWorktreeDir,
 } from "../../infra/storage/settings-store.js";
 import {
@@ -62,7 +62,7 @@ export async function createBranchWorktree(
     );
   }
 
-  const settings = await loadSettings(context.repoRoot);
+  const settings = await loadRepositorySettings(context.repoRoot);
   const { id, idAdjustedFrom } = resolveUniqueWorktreeId(
     normalizedBranchName,
     worktrees.map((worktree) => worktree.id)

--- a/src/app/use-cases/create-branch-worktree.ts
+++ b/src/app/use-cases/create-branch-worktree.ts
@@ -62,7 +62,7 @@ export async function createBranchWorktree(
     );
   }
 
-  const { settings, settingsRoot } = await loadRepositorySettings(
+  const { settings, worktreeDirRoot } = await loadRepositorySettings(
     context.repoRoot
   );
   const { id, idAdjustedFrom } = resolveUniqueWorktreeId(
@@ -72,7 +72,7 @@ export async function createBranchWorktree(
   const fullId = `${context.repoName}-${id}`;
   const worktreeBaseDir = resolveWorktreeDir(
     settings.worktreeDir,
-    settingsRoot
+    worktreeDirRoot
   );
 
   ensureWorktreeBaseDir(worktreeBaseDir);

--- a/src/app/use-cases/create-branch-worktree.ts
+++ b/src/app/use-cases/create-branch-worktree.ts
@@ -62,7 +62,9 @@ export async function createBranchWorktree(
     );
   }
 
-  const settings = await loadRepositorySettings(context.repoRoot);
+  const { settings, settingsRoot } = await loadRepositorySettings(
+    context.repoRoot
+  );
   const { id, idAdjustedFrom } = resolveUniqueWorktreeId(
     normalizedBranchName,
     worktrees.map((worktree) => worktree.id)
@@ -70,7 +72,7 @@ export async function createBranchWorktree(
   const fullId = `${context.repoName}-${id}`;
   const worktreeBaseDir = resolveWorktreeDir(
     settings.worktreeDir,
-    context.repoRoot
+    settingsRoot
   );
 
   ensureWorktreeBaseDir(worktreeBaseDir);

--- a/src/app/use-cases/create-pr-worktree.ts
+++ b/src/app/use-cases/create-pr-worktree.ts
@@ -111,7 +111,7 @@ export async function createPrWorktree(
     };
   }
 
-  const { settings, settingsRoot } = await loadRepositorySettings(
+  const { settings, worktreeDirRoot } = await loadRepositorySettings(
     context.repoRoot
   );
   const { id, idAdjustedFrom } = resolveUniqueWorktreeId(
@@ -121,7 +121,7 @@ export async function createPrWorktree(
   const fullId = `${context.repoName}-${id}`;
   const worktreeBaseDir = resolveWorktreeDir(
     settings.worktreeDir,
-    settingsRoot
+    worktreeDirRoot
   );
 
   ensureWorktreeBaseDir(worktreeBaseDir);

--- a/src/app/use-cases/create-pr-worktree.ts
+++ b/src/app/use-cases/create-pr-worktree.ts
@@ -10,9 +10,9 @@ import {
 } from "../worktree-creation.js";
 import { copyConfiguredPaths } from "../worktree-copy.js";
 import { requireRepositoryContext } from "../repository-context.js";
+import { loadRepositorySettings } from "../repository-settings.js";
 import { loadWorktreeInfos } from "../worktree-catalog.js";
 import {
-  loadSettings,
   resolveWorktreeDir,
 } from "../../infra/storage/settings-store.js";
 import {
@@ -111,7 +111,7 @@ export async function createPrWorktree(
     };
   }
 
-  const settings = await loadSettings(context.repoRoot);
+  const settings = await loadRepositorySettings(context.repoRoot);
   const { id, idAdjustedFrom } = resolveUniqueWorktreeId(
     preferredId,
     worktrees.map((worktree) => worktree.id)

--- a/src/app/use-cases/create-pr-worktree.ts
+++ b/src/app/use-cases/create-pr-worktree.ts
@@ -111,7 +111,9 @@ export async function createPrWorktree(
     };
   }
 
-  const settings = await loadRepositorySettings(context.repoRoot);
+  const { settings, settingsRoot } = await loadRepositorySettings(
+    context.repoRoot
+  );
   const { id, idAdjustedFrom } = resolveUniqueWorktreeId(
     preferredId,
     worktrees.map((worktree) => worktree.id)
@@ -119,7 +121,7 @@ export async function createPrWorktree(
   const fullId = `${context.repoName}-${id}`;
   const worktreeBaseDir = resolveWorktreeDir(
     settings.worktreeDir,
-    context.repoRoot
+    settingsRoot
   );
 
   ensureWorktreeBaseDir(worktreeBaseDir);

--- a/src/app/use-cases/create-worktree.ts
+++ b/src/app/use-cases/create-worktree.ts
@@ -89,7 +89,7 @@ export async function createWorktree(
   cwd: string = process.cwd()
 ): Promise<CreateWorktreeResult> {
   const context = await requireRepositoryContext(cwd);
-  const { settings, settingsRoot } = await loadRepositorySettings(
+  const { settings, worktreeDirRoot } = await loadRepositorySettings(
     context.repoRoot
   );
   const baseBranch = options.base ?? settings.baseBranch;
@@ -98,7 +98,7 @@ export async function createWorktree(
   const fullId = `${context.repoName}-${id}`;
   const worktreeBaseDir = resolveWorktreeDir(
     settings.worktreeDir,
-    settingsRoot
+    worktreeDirRoot
   );
 
   ensureWorktreeBaseDir(worktreeBaseDir);

--- a/src/app/use-cases/create-worktree.ts
+++ b/src/app/use-cases/create-worktree.ts
@@ -15,8 +15,8 @@ import {
 } from "../worktree-creation.js";
 import { copyConfiguredPaths } from "../worktree-copy.js";
 import { requireRepositoryContext } from "../repository-context.js";
+import { loadRepositorySettings } from "../repository-settings.js";
 import {
-  loadSettings,
   resolveWorktreeDir,
 } from "../../infra/storage/settings-store.js";
 import {
@@ -89,7 +89,7 @@ export async function createWorktree(
   cwd: string = process.cwd()
 ): Promise<CreateWorktreeResult> {
   const context = await requireRepositoryContext(cwd);
-  const settings = await loadSettings(context.repoRoot);
+  const settings = await loadRepositorySettings(context.repoRoot);
   const baseBranch = options.base ?? settings.baseBranch;
   const pushRemote = options.push ?? settings.pushRemote;
   const id = options.id ?? branchName;

--- a/src/app/use-cases/create-worktree.ts
+++ b/src/app/use-cases/create-worktree.ts
@@ -89,14 +89,16 @@ export async function createWorktree(
   cwd: string = process.cwd()
 ): Promise<CreateWorktreeResult> {
   const context = await requireRepositoryContext(cwd);
-  const settings = await loadRepositorySettings(context.repoRoot);
+  const { settings, settingsRoot } = await loadRepositorySettings(
+    context.repoRoot
+  );
   const baseBranch = options.base ?? settings.baseBranch;
   const pushRemote = options.push ?? settings.pushRemote;
   const id = options.id ?? branchName;
   const fullId = `${context.repoName}-${id}`;
   const worktreeBaseDir = resolveWorktreeDir(
     settings.worktreeDir,
-    context.repoRoot
+    settingsRoot
   );
 
   ensureWorktreeBaseDir(worktreeBaseDir);

--- a/src/app/use-cases/get-current-worktree.ts
+++ b/src/app/use-cases/get-current-worktree.ts
@@ -68,7 +68,7 @@ export async function getCurrentWorktree(
   cwd: string = process.cwd()
 ): Promise<GetCurrentWorktreeResult> {
   const context = await requireRepositoryContext(cwd);
-  const settings = await loadRepositorySettings(context.repoRoot);
+  const { settings } = await loadRepositorySettings(context.repoRoot);
   const worktree = enrichWorktreeWithIssueLink(
     await enrichWorktreeWithPullRequest(
       context.repoRoot,

--- a/src/app/use-cases/get-current-worktree.ts
+++ b/src/app/use-cases/get-current-worktree.ts
@@ -1,0 +1,84 @@
+import type { WtIssueSettings } from "../../domain/settings.js";
+import type { WorktreeInfo } from "../../domain/worktree.js";
+import { buildIssueLink } from "../../domain/issue-link.js";
+import { findPullRequestLinkForBranch } from "../../infra/github/cli.js";
+import { AppError } from "../errors.js";
+import { requireRepositoryContext } from "../repository-context.js";
+import { loadRepositorySettings } from "../repository-settings.js";
+import { loadCurrentWorktreeInfo } from "../worktree-catalog.js";
+
+export interface GetCurrentWorktreeResult {
+  repoName: string;
+  worktree: WorktreeInfo;
+}
+
+function enrichWorktreeWithIssueLink(
+  worktree: WorktreeInfo,
+  issueSettings: WtIssueSettings | undefined
+): WorktreeInfo {
+  if (!issueSettings) {
+    return worktree;
+  }
+
+  try {
+    const issueLink = buildIssueLink(worktree.branch, issueSettings);
+
+    if (!issueLink) {
+      return worktree;
+    }
+
+    return {
+      ...worktree,
+      issueKey: issueLink.key,
+      issueUrl: issueLink.url,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new AppError(
+      `Invalid issue.pattern "${issueSettings.pattern}": ${message}`
+    );
+  }
+}
+
+async function enrichWorktreeWithPullRequest(
+  repoRoot: string,
+  worktree: WorktreeInfo
+): Promise<WorktreeInfo> {
+  if (worktree.prUrl || !worktree.branch || worktree.isDetached) {
+    return worktree;
+  }
+
+  const pullRequest = await findPullRequestLinkForBranch(
+    repoRoot,
+    worktree.branch
+  );
+
+  if (!pullRequest) {
+    return worktree;
+  }
+
+  return {
+    ...worktree,
+    prNumber: pullRequest.number,
+    prUrl: pullRequest.url,
+  };
+}
+
+export async function getCurrentWorktree(
+  cwd: string = process.cwd()
+): Promise<GetCurrentWorktreeResult> {
+  const context = await requireRepositoryContext(cwd);
+  const settings = await loadRepositorySettings(context.repoRoot);
+  const worktree = enrichWorktreeWithIssueLink(
+    await enrichWorktreeWithPullRequest(
+      context.repoRoot,
+      await loadCurrentWorktreeInfo(context)
+    ),
+    settings.issue
+  );
+
+  return {
+    repoName: context.repoName,
+    worktree,
+  };
+}

--- a/src/app/use-cases/list-worktrees.ts
+++ b/src/app/use-cases/list-worktrees.ts
@@ -125,7 +125,7 @@ export async function listWorktrees(
   cwd: string = process.cwd()
 ): Promise<ListWorktreesResult> {
   const context = await requireRepositoryContext(cwd);
-  const settings = await loadRepositorySettings(context.repoRoot);
+  const { settings } = await loadRepositorySettings(context.repoRoot);
   const worktreesWithIssueLinks = enrichWorktreesWithIssueLinks(
     settings.issue,
     await loadWorktreeStates(context)

--- a/src/app/use-cases/list-worktrees.ts
+++ b/src/app/use-cases/list-worktrees.ts
@@ -7,12 +7,12 @@ import { requireRepositoryContext } from "../repository-context.js";
 import { AppError } from "../errors.js";
 import { buildIssueLinkFromPattern } from "../../domain/issue-link.js";
 import { listPullRequestLinks } from "../../infra/github/cli.js";
-import { loadSettings } from "../../infra/storage/settings-store.js";
 import {
   loadWorktreeInfos,
   loadWorktreeRemovalInfos,
   loadWorktreeStates,
 } from "../worktree-catalog.js";
+import { loadRepositorySettings } from "../repository-settings.js";
 import type { WtIssueSettings } from "../../domain/settings.js";
 
 export interface ListWorktreeInfosOptions {
@@ -125,7 +125,7 @@ export async function listWorktrees(
   cwd: string = process.cwd()
 ): Promise<ListWorktreesResult> {
   const context = await requireRepositoryContext(cwd);
-  const settings = await loadSettings(context.repoRoot);
+  const settings = await loadRepositorySettings(context.repoRoot);
   const worktreesWithIssueLinks = enrichWorktreesWithIssueLinks(
     settings.issue,
     await loadWorktreeStates(context)

--- a/src/app/worktree-catalog.ts
+++ b/src/app/worktree-catalog.ts
@@ -1,7 +1,9 @@
 import { statSync } from "fs";
 import type { RepositoryContext } from "./repository-context.js";
+import { AppError } from "./errors.js";
 import {
   buildWorktreeIdentifiers,
+  type GitWorktreeRef,
   type WorktreeInfo,
   type WorktreeMergeStatus,
   type WorktreeRemovalInfo,
@@ -31,37 +33,55 @@ function resolveCreatedAt(
   }
 }
 
+async function buildWorktreeInfo(
+  context: RepositoryContext,
+  worktree: GitWorktreeRef
+): Promise<WorktreeInfo> {
+  const meta = await readWorktreeMeta(worktree.path);
+  const { id, fullId } = buildWorktreeIdentifiers(
+    context.repoName,
+    worktree.path,
+    meta
+  );
+
+  return {
+    id,
+    fullId,
+    path: worktree.path,
+    branch: worktree.branch,
+    isMain: worktree.isMain,
+    isDetached: worktree.isDetached,
+    head: worktree.head,
+    repoName: context.repoName,
+    createdAt: resolveCreatedAt(worktree.path, meta?.createdAt),
+    baseBranch: meta?.baseBranch,
+    baseCommit: meta?.baseCommit,
+    prNumber: meta?.prNumber,
+    prUrl: meta?.prUrl,
+  };
+}
+
 export async function loadWorktreeInfos(
   context: RepositoryContext
 ): Promise<WorktreeInfo[]> {
   const gitWorktrees = await listGitWorktrees(context.repoRoot);
 
-  return Promise.all(
-    gitWorktrees.map(async (worktree) => {
-      const meta = await readWorktreeMeta(worktree.path);
-      const { id, fullId } = buildWorktreeIdentifiers(
-        context.repoName,
-        worktree.path,
-        meta
-      );
+  return Promise.all(gitWorktrees.map((worktree) => buildWorktreeInfo(context, worktree)));
+}
 
-      return {
-        id,
-        fullId,
-        path: worktree.path,
-        branch: worktree.branch,
-        isMain: worktree.isMain,
-        isDetached: worktree.isDetached,
-        head: worktree.head,
-        repoName: context.repoName,
-        createdAt: resolveCreatedAt(worktree.path, meta?.createdAt),
-        baseBranch: meta?.baseBranch,
-        baseCommit: meta?.baseCommit,
-        prNumber: meta?.prNumber,
-        prUrl: meta?.prUrl,
-      };
-    })
+export async function loadCurrentWorktreeInfo(
+  context: RepositoryContext
+): Promise<WorktreeInfo> {
+  const gitWorktrees = await listGitWorktrees(context.repoRoot);
+  const currentWorktree = gitWorktrees.find(
+    (worktree) => worktree.path === context.repoRoot
   );
+
+  if (!currentWorktree) {
+    throw new AppError("Current directory is not inside a git worktree");
+  }
+
+  return buildWorktreeInfo(context, currentWorktree);
 }
 
 export async function loadWorktreeStates(

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -1756,6 +1756,100 @@ describe("cli e2e", () => {
     expect(listResult.stdout).toContain(`PR:      #${prNumber} ${prUrl}`);
   });
 
+  test("shows the current linked worktree with a derived issue tracker URL", async () => {
+    const repo = await createTestRepo();
+    const worktreeId = "dev-123";
+    const branchName = "feature/DEV-123";
+
+    updateSettings(repo.repoRoot, settings => {
+      settings.issue = {
+        pattern: "[A-Z]+-\\d+",
+        url: "https://myissues.com/$issue",
+      };
+    });
+    runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
+
+    const worktreePath = getWorktreePath(repo, worktreeId);
+    const nestedDir = join(worktreePath, "nested");
+    mkdirSync(nestedDir, { recursive: true });
+
+    const result = runCliCapture(["current"], nestedDir);
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+
+    expect(result.stdout).toContain(`ID:      ${worktreeId} (current)`);
+    expect(result.stdout).toContain(`Branch:  ${branchName}`);
+    expect(result.stdout).toContain(
+      "Issue:   DEV-123 https://myissues.com/DEV-123"
+    );
+    expect(result.stdout).toContain(`Path:    ${realpathSync(worktreePath)}`);
+  });
+
+  test("shows stored PR metadata for the current worktree without querying GitHub again", async () => {
+    const repo = await createTestRepo();
+    const prNumber = "790";
+    const branchName = "feature-pr-current";
+    const prUrl = "https://github.com/example/repo/pull/790";
+    const ghLogPath = join(repo.repoRoot, "gh.log");
+
+    const createResult = runCliCapture(["pr", prNumber, "--no-cd"], repo.repoRoot, {
+      env: createFakeGithubEnv({
+        headBranch: branchName,
+        logPath: ghLogPath,
+        prNumber,
+        prUrl,
+      }),
+    });
+    assertProcessSuccess(
+      createResult.status,
+      createResult.stderr,
+      createResult.stdout
+    );
+
+    const worktreePath = getWorktreePath(repo, `pr-${prNumber}`);
+    const ghLogBefore = readFileSync(ghLogPath, "utf-8");
+    const result = runCliCapture(["current"], worktreePath, {
+      env: createFakeGithubEnv({
+        headBranch: branchName,
+        logPath: ghLogPath,
+        prNumber,
+        prUrl,
+      }),
+    });
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+
+    expect(result.stdout).toContain(`ID:      pr-${prNumber} (current)`);
+    expect(result.stdout).toContain(`PR:      #${prNumber} ${prUrl}`);
+    expect(readFileSync(ghLogPath, "utf-8")).toBe(ghLogBefore);
+  });
+
+  test("looks up PR metadata for the current branch worktree when none is stored", async () => {
+    const repo = await createTestRepo();
+    const worktreeId = "pr-lookup";
+    const branchName = "feature/pr-lookup";
+    const prNumber = "791";
+    const prUrl = "https://github.com/example/repo/pull/791";
+    const ghLogPath = join(repo.repoRoot, "gh.log");
+
+    runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
+
+    const worktreePath = getWorktreePath(repo, worktreeId);
+    const result = runCliCapture(["current"], worktreePath, {
+      env: createFakeGithubEnv({
+        headBranch: branchName,
+        logPath: ghLogPath,
+        prNumber,
+        prUrl,
+      }),
+    });
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+
+    expect(result.stdout).toContain(`ID:      ${worktreeId} (current)`);
+    expect(result.stdout).toContain(`PR:      #${prNumber} ${prUrl}`);
+    expect(readFileSync(ghLogPath, "utf-8")).toContain(
+      `pr view ${branchName} --json number,url`
+    );
+  });
+
   test("lists a detached main worktree instead of hiding it", async () => {
     const repo = await createGitRepo();
 

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -295,6 +295,18 @@ function createFakeGithubEnv(
         "  exit 1",
         "fi",
         'if [ "$1" = "pr" ] && [ "${2:-}" = "list" ]; then',
+        '  target_head=""',
+        '  previous_arg=""',
+        '  for arg in "$@"; do',
+        '    if [ "$previous_arg" = "--head" ]; then',
+        '      target_head="$arg"',
+        "    fi",
+        '    previous_arg="$arg"',
+        "  done",
+        `  if [ -n "$target_head" ] && [ "$target_head" != "${headBranch}" ]; then`,
+        "    printf '%s\\n' '[]'",
+        "    exit 0",
+        "  fi",
         `  printf '%s\\n' '[{"number":${prNumber},"url":"${prUrl}","headRefName":"${headBranch}"}]'`,
         "  exit 0",
         "fi",
@@ -1846,8 +1858,38 @@ describe("cli e2e", () => {
     expect(result.stdout).toContain(`ID:      ${worktreeId} (current)`);
     expect(result.stdout).toContain(`PR:      #${prNumber} ${prUrl}`);
     expect(readFileSync(ghLogPath, "utf-8")).toContain(
-      `pr view ${branchName} --json number,url`
+      `pr list --state open --head ${branchName} --json number,url`
     );
+  });
+
+  test("looks up numeric current branch names as PR heads instead of PR numbers", async () => {
+    const repo = await createTestRepo();
+    const worktreeId = "numeric-branch";
+    const branchName = "123";
+    const prNumber = "792";
+    const prUrl = "https://github.com/example/repo/pull/792";
+    const ghLogPath = join(repo.repoRoot, "gh.log");
+
+    runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
+
+    const worktreePath = getWorktreePath(repo, worktreeId);
+    const result = runCliCapture(["current"], worktreePath, {
+      env: createFakeGithubEnv({
+        headBranch: branchName,
+        logPath: ghLogPath,
+        prNumber,
+        prUrl,
+      }),
+    });
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+
+    const ghLog = readFileSync(ghLogPath, "utf-8");
+
+    expect(result.stdout).toContain(`PR:      #${prNumber} ${prUrl}`);
+    expect(ghLog).toContain(
+      `pr list --state open --head ${branchName} --json number,url`
+    );
+    expect(ghLog).not.toContain(`pr view ${branchName}`);
   });
 
   test("lists a detached main worktree instead of hiding it", async () => {
@@ -2966,6 +3008,8 @@ describe("cli e2e", () => {
     updateSettings(repo.repoRoot, settings => {
       settings.worktreeDir = "./worktrees";
     });
+    await $`git -C ${repo.repoRoot} add .wt/settings.json`.quiet();
+    await $`git -C ${repo.repoRoot} commit -m track-settings`.quiet();
     runCli(
       ["new", firstBranchName, "--id", firstWorktreeId, "--no-cd"],
       repo.repoRoot
@@ -2983,6 +3027,52 @@ describe("cli e2e", () => {
     expect(existsSync(secondWorktreePath)).toBeTrue();
     expect(existsSync(join(secondWorktreePath, ".wt", "meta.json"))).toBeTrue();
     expect(existsSync(join(firstWorktreePath, "worktrees"))).toBeFalse();
+    expect(result.stdout).toContain(`WT_PATH: ${resolvedWorktreePath}`);
+    expect(result.stdout).toContain(`cd ${resolvedWorktreePath}`);
+  });
+
+  test("resolves current local worktreeDir overrides from the linked worktree", async () => {
+    const repo = await createTestRepo();
+    const firstWorktreeId = "relative-local-source";
+    const secondWorktreeId = "relative-local-target";
+    const firstBranchName = "feature-relative-local-source";
+    const secondBranchName = "feature-relative-local-target";
+    const mainWorktreeRoot = join(repo.repoRoot, "worktrees");
+    const firstWorktreePath = join(
+      mainWorktreeRoot,
+      `${repo.repoName}-${firstWorktreeId}`
+    );
+    const expectedWorktreeRoot = join(firstWorktreePath, "local-worktrees");
+    const expectedWorktreePath = join(
+      expectedWorktreeRoot,
+      `${repo.repoName}-${secondWorktreeId}`
+    );
+
+    updateSettings(repo.repoRoot, settings => {
+      settings.worktreeDir = "./worktrees";
+    });
+    await $`git -C ${repo.repoRoot} add .wt/settings.json`.quiet();
+    await $`git -C ${repo.repoRoot} commit -m track-settings`.quiet();
+    runCli(
+      ["new", firstBranchName, "--id", firstWorktreeId, "--no-cd"],
+      repo.repoRoot
+    );
+    writeFileSync(
+      join(firstWorktreePath, ".wt", "settings.local.json"),
+      JSON.stringify({ worktreeDir: "./local-worktrees" }, null, 2)
+    );
+
+    const result = runCliCapture(
+      ["new", secondBranchName, "--id", secondWorktreeId, "--no-cd"],
+      firstWorktreePath
+    );
+
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+
+    const resolvedWorktreePath = realpathSync(expectedWorktreePath);
+
+    expect(existsSync(expectedWorktreePath)).toBeTrue();
+    expect(existsSync(join(expectedWorktreePath, ".wt", "meta.json"))).toBeTrue();
     expect(result.stdout).toContain(`WT_PATH: ${resolvedWorktreePath}`);
     expect(result.stdout).toContain(`cd ${resolvedWorktreePath}`);
   });

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -2946,4 +2946,44 @@ describe("cli e2e", () => {
     expect(result.stdout).toContain(`WT_PATH: ${resolvedWorktreePath}`);
     expect(result.stdout).toContain(`cd ${resolvedWorktreePath}`);
   });
+
+  test("resolves fallback relative worktreeDir from the main worktree", async () => {
+    const repo = await createTestRepo();
+    const firstWorktreeId = "relative-source";
+    const secondWorktreeId = "relative-target";
+    const firstBranchName = "feature-relative-source";
+    const secondBranchName = "feature-relative-target";
+    const expectedWorktreeRoot = join(repo.repoRoot, "worktrees");
+    const firstWorktreePath = join(
+      expectedWorktreeRoot,
+      `${repo.repoName}-${firstWorktreeId}`
+    );
+    const secondWorktreePath = join(
+      expectedWorktreeRoot,
+      `${repo.repoName}-${secondWorktreeId}`
+    );
+
+    updateSettings(repo.repoRoot, settings => {
+      settings.worktreeDir = "./worktrees";
+    });
+    runCli(
+      ["new", firstBranchName, "--id", firstWorktreeId, "--no-cd"],
+      repo.repoRoot
+    );
+
+    const result = runCliCapture(
+      ["new", secondBranchName, "--id", secondWorktreeId, "--no-cd"],
+      firstWorktreePath
+    );
+
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+
+    const resolvedWorktreePath = realpathSync(secondWorktreePath);
+
+    expect(existsSync(secondWorktreePath)).toBeTrue();
+    expect(existsSync(join(secondWorktreePath, ".wt", "meta.json"))).toBeTrue();
+    expect(existsSync(join(firstWorktreePath, "worktrees"))).toBeFalse();
+    expect(result.stdout).toContain(`WT_PATH: ${resolvedWorktreePath}`);
+    expect(result.stdout).toContain(`cd ${resolvedWorktreePath}`);
+  });
 });

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -3076,4 +3076,50 @@ describe("cli e2e", () => {
     expect(result.stdout).toContain(`WT_PATH: ${resolvedWorktreePath}`);
     expect(result.stdout).toContain(`cd ${resolvedWorktreePath}`);
   });
+
+  test("resolves changed linked shared worktreeDir from the linked worktree", async () => {
+    const repo = await createTestRepo();
+    const firstWorktreeId = "relative-shared-source";
+    const secondWorktreeId = "relative-shared-target";
+    const firstBranchName = "feature-relative-shared-source";
+    const secondBranchName = "feature-relative-shared-target";
+    const mainWorktreeRoot = join(repo.repoRoot, "worktrees");
+    const firstWorktreePath = join(
+      mainWorktreeRoot,
+      `${repo.repoName}-${firstWorktreeId}`
+    );
+    const expectedWorktreeRoot = join(firstWorktreePath, "branch-worktrees");
+    const expectedWorktreePath = join(
+      expectedWorktreeRoot,
+      `${repo.repoName}-${secondWorktreeId}`
+    );
+
+    updateSettings(repo.repoRoot, settings => {
+      settings.worktreeDir = "./worktrees";
+    });
+    await $`git -C ${repo.repoRoot} add .wt/settings.json`.quiet();
+    await $`git -C ${repo.repoRoot} commit -m track-settings`.quiet();
+    runCli(
+      ["new", firstBranchName, "--id", firstWorktreeId, "--no-cd"],
+      repo.repoRoot
+    );
+    writeFileSync(
+      join(firstWorktreePath, ".wt", "settings.json"),
+      JSON.stringify({ worktreeDir: "./branch-worktrees" }, null, 2)
+    );
+
+    const result = runCliCapture(
+      ["new", secondBranchName, "--id", secondWorktreeId, "--no-cd"],
+      firstWorktreePath
+    );
+
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+
+    const resolvedWorktreePath = realpathSync(expectedWorktreePath);
+
+    expect(existsSync(expectedWorktreePath)).toBeTrue();
+    expect(existsSync(join(expectedWorktreePath, ".wt", "meta.json"))).toBeTrue();
+    expect(result.stdout).toContain(`WT_PATH: ${resolvedWorktreePath}`);
+    expect(result.stdout).toContain(`cd ${resolvedWorktreePath}`);
+  });
 });

--- a/src/commands/current.ts
+++ b/src/commands/current.ts
@@ -1,0 +1,39 @@
+import chalk from "chalk";
+import { getCurrentWorktree } from "../app/use-cases/get-current-worktree.js";
+import { runCommand } from "../cli/command-runtime.js";
+import {
+  buildIssueSummary,
+  buildPullRequestSummary,
+  buildWorktreeBranchSummary,
+  buildWorktreeIdLabel,
+} from "./worktree-display.js";
+
+export async function currentCommand(): Promise<void> {
+  await runCommand(async () => {
+    const result = await getCurrentWorktree();
+    const { worktree } = result;
+    const pullRequestSummary = buildPullRequestSummary(worktree);
+    const issueSummary = buildIssueSummary(worktree);
+    const timestamp = new Date(worktree.createdAt).toLocaleString();
+
+    console.log(chalk.bold(`\nCurrent worktree (${result.repoName}):`));
+    console.log(chalk.dim("─".repeat(80)));
+    console.log(
+      chalk.cyan(
+        `ID:      ${buildWorktreeIdLabel({ ...worktree, isCurrent: true })}`
+      )
+    );
+    console.log(
+      chalk.white(`Branch:  ${buildWorktreeBranchSummary(worktree)}`)
+    );
+    if (issueSummary) {
+      console.log(`Issue:   ${issueSummary}`);
+    }
+    if (pullRequestSummary) {
+      console.log(`PR:      ${pullRequestSummary}`);
+    }
+    console.log(chalk.dim(`Path:    ${worktree.path}`));
+    console.log(chalk.dim(`Created: ${timestamp}`));
+    console.log(chalk.dim("─".repeat(80)));
+  });
+}

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -14,6 +14,8 @@ import type {
 import { runCommand } from "../cli/command-runtime.js";
 import {
   buildBaseDescription,
+  buildIssueSummary,
+  buildPullRequestSummary,
   buildWorktreeBranchSummary,
   buildWorktreeIdLabel,
 } from "./worktree-display.js";
@@ -140,28 +142,4 @@ function buildRemoveCompletionDescription(
   }
 
   return `${getWorktreeBranchLabel(worktree)} | ${metadata.join(" | ")}`;
-}
-
-function buildPullRequestSummary(
-  worktree: Pick<WorktreeState, "prNumber" | "prUrl">
-): string | undefined {
-  if (!worktree.prUrl) {
-    return undefined;
-  }
-
-  return worktree.prNumber
-    ? `#${worktree.prNumber} ${worktree.prUrl}`
-    : worktree.prUrl;
-}
-
-function buildIssueSummary(
-  worktree: Pick<WorktreeState, "issueKey" | "issueUrl">
-): string | undefined {
-  if (!worktree.issueUrl) {
-    return undefined;
-  }
-
-  return worktree.issueKey
-    ? `${worktree.issueKey} ${worktree.issueUrl}`
-    : worktree.issueUrl;
 }

--- a/src/commands/worktree-display.ts
+++ b/src/commands/worktree-display.ts
@@ -99,6 +99,30 @@ export function buildWorktreeBranchSummary(
   return branchParts.join(" ");
 }
 
+export function buildPullRequestSummary(
+  worktree: Pick<WorktreeInfo, "prNumber" | "prUrl">
+): string | undefined {
+  if (!worktree.prUrl) {
+    return undefined;
+  }
+
+  return worktree.prNumber
+    ? `#${worktree.prNumber} ${worktree.prUrl}`
+    : worktree.prUrl;
+}
+
+export function buildIssueSummary(
+  worktree: Pick<WorktreeInfo, "issueKey" | "issueUrl">
+): string | undefined {
+  if (!worktree.issueUrl) {
+    return undefined;
+  }
+
+  return worktree.issueKey
+    ? `${worktree.issueKey} ${worktree.issueUrl}`
+    : worktree.issueUrl;
+}
+
 export function pickDisplayState(
   worktree: Pick<DisplayableWorktree, "id">,
   statesById: Map<string, WorktreeState>

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Command, Option } from "commander";
 import { initCommand } from "./commands/init.js";
 import { newCommand } from "./commands/new.js";
 import { listCommand } from "./commands/list.js";
+import { currentCommand } from "./commands/current.js";
 import { removeCommand } from "./commands/remove.js";
 import { renameCommand } from "./commands/rename.js";
 import { cleanCommand } from "./commands/clean.js";
@@ -43,6 +44,11 @@ program
   .option("--completion <format>", "Output completion format (bash, zsh, fish)")
   .addOption(new Option("--exclude-main-worktree").hideHelp())
   .action(listCommand);
+
+program
+  .command("current")
+  .description("Show the current worktree")
+  .action(currentCommand);
 
 program
   .command("remove <ids...>")

--- a/src/infra/github/cli.ts
+++ b/src/infra/github/cli.ts
@@ -63,25 +63,31 @@ function getGithubErrorMessage(result: GithubCommandResult): string {
   return result.stderr.trim() || result.stdout.trim() || "unknown gh error";
 }
 
-function parsePullRequestLink(
-  stdout: string
-): PullRequestLink | undefined {
-  let entry: Partial<PullRequestLinkEntry>;
+function parsePullRequestLinkList(stdout: string): PullRequestLink[] {
+  let entries: Partial<PullRequestLinkEntry>[];
 
   try {
-    entry = JSON.parse(stdout) as Partial<PullRequestLinkEntry>;
+    entries = JSON.parse(stdout) as Partial<PullRequestLinkEntry>[];
   } catch {
-    return undefined;
+    return [];
   }
 
-  if (typeof entry.number !== "number" || !entry.url) {
-    return undefined;
+  if (!Array.isArray(entries)) {
+    return [];
   }
 
-  return {
-    number: String(entry.number),
-    url: entry.url,
-  };
+  return entries.flatMap((entry) => {
+    if (typeof entry.number !== "number" || !entry.url) {
+      return [];
+    }
+
+    return [
+      {
+        number: String(entry.number),
+        url: entry.url,
+      },
+    ];
+  });
 }
 
 export async function ensureGithubCliReady(cwd: string): Promise<void> {
@@ -225,7 +231,16 @@ export async function findPullRequestLinkForBranch(
   branchName: string
 ): Promise<PullRequestLink | undefined> {
   const result = runGithubCommand(
-    ["pr", "view", branchName, "--json", "number,url"],
+    [
+      "pr",
+      "list",
+      "--state",
+      "open",
+      "--head",
+      branchName,
+      "--json",
+      "number,url",
+    ],
     repoRoot
   );
 
@@ -233,7 +248,9 @@ export async function findPullRequestLinkForBranch(
     return undefined;
   }
 
-  return parsePullRequestLink(result.stdout);
+  const pullRequests = parsePullRequestLinkList(result.stdout);
+
+  return pullRequests.length === 1 ? pullRequests[0] : undefined;
 }
 
 export async function checkoutPullRequest(

--- a/src/infra/github/cli.ts
+++ b/src/infra/github/cli.ts
@@ -27,6 +27,11 @@ interface PullRequestListEntry {
   url: string;
 }
 
+interface PullRequestLinkEntry {
+  number: number;
+  url: string;
+}
+
 function runGithubCommand(
   args: string[],
   cwd: string
@@ -56,6 +61,27 @@ function isGithubCliUnavailable(result: GithubCommandResult): boolean {
 
 function getGithubErrorMessage(result: GithubCommandResult): string {
   return result.stderr.trim() || result.stdout.trim() || "unknown gh error";
+}
+
+function parsePullRequestLink(
+  stdout: string
+): PullRequestLink | undefined {
+  let entry: Partial<PullRequestLinkEntry>;
+
+  try {
+    entry = JSON.parse(stdout) as Partial<PullRequestLinkEntry>;
+  } catch {
+    return undefined;
+  }
+
+  if (typeof entry.number !== "number" || !entry.url) {
+    return undefined;
+  }
+
+  return {
+    number: String(entry.number),
+    url: entry.url,
+  };
 }
 
 export async function ensureGithubCliReady(cwd: string): Promise<void> {
@@ -192,6 +218,22 @@ export async function listPullRequestLinks(
       (entry): entry is [string, PullRequestLink] => entry[1] !== null
     )
   );
+}
+
+export async function findPullRequestLinkForBranch(
+  repoRoot: string,
+  branchName: string
+): Promise<PullRequestLink | undefined> {
+  const result = runGithubCommand(
+    ["pr", "view", branchName, "--json", "number,url"],
+    repoRoot
+  );
+
+  if (result.status !== 0) {
+    return undefined;
+  }
+
+  return parsePullRequestLink(result.stdout);
 }
 
 export async function checkoutPullRequest(

--- a/src/infra/shell/installer.test.ts
+++ b/src/infra/shell/installer.test.ts
@@ -38,6 +38,7 @@ describe("shell installer", () => {
         })
       );
       expect(wrapper).toContain('clean[Bulk-remove worktrees interactively]');
+      expect(wrapper).toContain('current[Show the current worktree]');
       expect(wrapper).toContain('rename[Rename the current worktree ID]');
     } finally {
       rmSync(shellDir, { recursive: true, force: true });

--- a/src/infra/shell/installer.ts
+++ b/src/infra/shell/installer.ts
@@ -227,6 +227,7 @@ _wt_completion() {
         'switch[Alias for checkout]' \\
         'list[List all worktrees]' \\
         'ls[List all worktrees]' \\
+        'current[Show the current worktree]' \\
         'remove[Remove a worktree]' \\
         'rm[Remove a worktree]' \\
         'rename[Rename the current worktree ID]' \\

--- a/src/infra/storage/settings-store.ts
+++ b/src/infra/storage/settings-store.ts
@@ -21,6 +21,10 @@ export async function getSettingsPath(repoRoot: string): Promise<string> {
   return join(repoRoot, ".wt", "settings.json");
 }
 
+export async function getLocalSettingsPath(repoRoot: string): Promise<string> {
+  return join(repoRoot, ".wt", "settings.local.json");
+}
+
 export async function settingsExist(repoRoot: string): Promise<boolean> {
   const settingsPath = await getSettingsPath(repoRoot);
   return existsSync(settingsPath);
@@ -36,13 +40,27 @@ async function readSettingsInput(
   return JSON.parse(await Bun.file(settingsPath).text()) as WtSettingsInput;
 }
 
-export async function loadSettings(repoRoot: string): Promise<WtSettings> {
-  const settingsPath = await getSettingsPath(repoRoot);
-  const localSettingsPath = join(repoRoot, ".wt", "settings.local.json");
-  const sharedSettings = await readSettingsInput(settingsPath);
-  const localSettings = await readSettingsInput(localSettingsPath);
+export interface SettingsInputs {
+  shared?: WtSettingsInput;
+  local?: WtSettingsInput;
+}
 
-  return normalizeSettings(mergeSettingsInputs(sharedSettings, localSettings));
+export async function loadSettingsInputs(
+  repoRoot: string
+): Promise<SettingsInputs> {
+  const settingsPath = await getSettingsPath(repoRoot);
+  const localSettingsPath = await getLocalSettingsPath(repoRoot);
+
+  return {
+    shared: await readSettingsInput(settingsPath),
+    local: await readSettingsInput(localSettingsPath),
+  };
+}
+
+export async function loadSettings(repoRoot: string): Promise<WtSettings> {
+  const { shared, local } = await loadSettingsInputs(repoRoot);
+
+  return normalizeSettings(mergeSettingsInputs(shared, local));
 }
 
 export async function ensureLocalSettingsIgnored(


### PR DESCRIPTION
## What changed
- add `wt current` to show only the current worktree without walking and enriching the full worktree list
- reuse repository settings from the main worktree when running inside a linked worktree
- auto-resolve the current branch's open PR in `wt current` only when PR metadata is not already stored
- cover the new current-worktree and PR lookup flows with end-to-end tests

## Why
`wt ls` is useful for the full catalog, but it is heavier than needed when the goal is just to inspect the current worktree. This adds a fast path for the current worktree and keeps PR lookup scoped to a single branch instead of the whole repo.

## Impact
- faster current-worktree inspection path
- linked worktrees can still resolve issue/PR-related output correctly
- `wt current` uses stored PR metadata first and falls back to a branch-scoped open PR lookup only when needed

## Validation
- `bun run typecheck`
- `bun test`