### PR TITLE
feat: improve Herdr worktree lifecycle

### DIFF
--- a/.changeset/close-herdr-workspaces.md
+++ b/.changeset/close-herdr-workspaces.md
@@ -2,4 +2,4 @@
 "@leesangb/wt": minor
 ---
 
-Close the Herdr workspace associated with a worktree removed by `wt rm`, with a `herdr.closeWorkspaceOnRemove` setting to opt out.
+Close the Herdr workspace associated with a worktree removed by `wt rm`, with a `herdr.closeWorkspaceOnRemove` setting to opt out. Herdr workspaces opened with `--no-cd` now preserve the current focus.

--- a/.changeset/close-herdr-workspaces.md
+++ b/.changeset/close-herdr-workspaces.md
@@ -2,4 +2,4 @@
 "@leesangb/wt": minor
 ---
 
-Close the Herdr workspace associated with a worktree removed by `wt rm`.
+Close the Herdr workspace associated with a worktree removed by `wt rm`, with a `herdr.closeWorkspaceOnRemove` setting to opt out.

--- a/.changeset/close-herdr-workspaces.md
+++ b/.changeset/close-herdr-workspaces.md
@@ -1,0 +1,5 @@
+---
+"@leesangb/wt": minor
+---
+
+Close the Herdr workspace associated with a worktree removed by `wt rm`.

--- a/.changeset/close-herdr-workspaces.md
+++ b/.changeset/close-herdr-workspaces.md
@@ -2,4 +2,4 @@
 "@leesangb/wt": minor
 ---
 
-Close the Herdr workspace associated with a worktree removed by `wt rm`, with a `herdr.closeWorkspaceOnRemove` setting to opt out. Herdr workspaces opened with `--no-cd` now preserve the current focus.
+Close the Herdr workspace associated with a worktree removed by `wt rm`, with a `herdr.closeWorkspaceOnRemove` setting to opt out. Herdr workspaces opened with `--no-cd` now preserve the current focus. Shell completion for `wt pr` now lists open GitHub pull requests.

--- a/.changeset/close-herdr-workspaces.md
+++ b/.changeset/close-herdr-workspaces.md
@@ -1,5 +1,5 @@
 ---
-"@leesangb/wt": minor
+"@leesangb/wt": patch
 ---
 
 Close the Herdr workspace associated with a worktree removed by `wt rm`, with a `herdr.closeWorkspaceOnRemove` setting to opt out. Herdr workspaces opened with `--no-cd` now preserve the current focus. Shell completion for `wt pr` now lists open GitHub pull requests.

--- a/README.ko.md
+++ b/README.ko.md
@@ -333,7 +333,7 @@ worktree에 수정된 파일이나 push되지 않은 커밋이 남아 있으면,
 
 현재 디렉터리가 속한 worktree를 제거할 때는 `wt rm`이 삭제 작업을 백그라운드로 시작하고, shell은 즉시 main worktree로 돌아갑니다. 출력에는 백그라운드 작업 PID와 main worktree의 `.wt/` 아래에 생성된 status/log 파일 경로가 표시됩니다. macOS에서는 백그라운드 삭제 성공 또는 실패를 알림으로 알려줍니다. 삭제가 끝날 때까지 기다리고 싶으면 `wt rm . --foreground`를 사용하세요.
 
-Herdr 안에서 실행하면 `wt rm`은 제거한 worktree에 연결된 Herdr workspace도 닫습니다. 백그라운드 제거에서는 작업 완료를 기다리지 않고 제거 작업이 시작되는 즉시 workspace를 닫습니다.
+Herdr 안에서 실행하면 `wt rm`은 제거한 worktree에 연결된 Herdr workspace도 닫습니다. 백그라운드 제거에서는 작업 완료를 기다리지 않고 제거 작업이 시작되는 즉시 workspace를 닫습니다. 계속 열어 두려면 `herdr.closeWorkspaceOnRemove`를 `false`로 설정하세요.
 
 다음 방법으로 worktree를 제거할 수 있습니다:
 - ID (기본값: 브랜치 이름, 예: `feature/issue-12`)
@@ -369,10 +369,11 @@ wt clean -m -d --keep-branch
 - **scripts.pre**: worktree 생성 전에 실행할 명령어 배열 (저장소 루트에서 실행)
 - **scripts.post**: worktree 생성 후에 실행할 명령어 배열 (새 worktree 디렉토리에서 실행)
 - **scripts.postMode**: `async`(기본값) 또는 `sync`(포그라운드 실행)
+- **herdr.closeWorkspaceOnRemove**: `wt rm` 후 연결된 Herdr workspace 닫기 (기본값: `true`)
 - **issue.pattern**: 브랜치 이름에서 이슈 키를 추출할 선택적 JavaScript 정규식
 - **issue.url**: 선택적 이슈 트래커 URL 템플릿. 추출한 키가 들어갈 위치에 `$issue`를 사용합니다
 
-사용자별 또는 머신별 override가 필요하면 선택적으로 `.wt/settings.local.json`도 둘 수 있습니다. `wt`는 먼저 `.wt/settings.json`을 읽고, 그 위에 `.wt/settings.local.json`을 덮어씁니다. 중첩된 `copy.*`, `scripts.*`, `issue.*` 필드도 병합되므로 `copy.exclude`, `scripts.postMode`, `issue.url`만 따로 바꿀 수 있습니다.
+사용자별 또는 머신별 override가 필요하면 선택적으로 `.wt/settings.local.json`도 둘 수 있습니다. `wt`는 먼저 `.wt/settings.json`을 읽고, 그 위에 `.wt/settings.local.json`을 덮어씁니다. 중첩된 `copy.*`, `scripts.*`, `herdr.*`, `issue.*` 필드도 병합되므로 `copy.exclude`, `scripts.postMode`, `herdr.closeWorkspaceOnRemove`, `issue.url`만 따로 바꿀 수 있습니다.
 
 `copy.include`와 `copy.exclude`는 저장소 루트를 기준으로 해석됩니다. 앞에 `./`를 붙여도 되고, `./apps`와 `apps`는 같은 의미입니다. `.wt`나 `apps/web`처럼 디렉토리 이름만 적으면 `/**`를 붙인 것처럼 하위 전체에 적용됩니다. `wt`는 source 저장소에서 git에 트래킹되지 않은 파일만 복사하고, 새로 만든 worktree 쪽에서 이미 tracked인 파일은 덮어쓰지 않습니다. 또한 항상 `.git`, `node_modules`, 그리고 현재 `.gitignore`에 의해 무시되는 디렉토리를 건너뜁니다. `.wt/meta.json`, `.wt/.gitignore`, async post-task 상태 파일처럼 `wt`가 내부적으로 쓰는 예약 파일은 계속 `wt`가 관리합니다.
 
@@ -397,6 +398,9 @@ wt clean -m -d --keep-branch
   "baseBranch": "develop",
   "scripts": {
     "postMode": "sync"
+  },
+  "herdr": {
+    "closeWorkspaceOnRemove": false
   }
 }
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -333,6 +333,8 @@ worktree에 수정된 파일이나 push되지 않은 커밋이 남아 있으면,
 
 현재 디렉터리가 속한 worktree를 제거할 때는 `wt rm`이 삭제 작업을 백그라운드로 시작하고, shell은 즉시 main worktree로 돌아갑니다. 출력에는 백그라운드 작업 PID와 main worktree의 `.wt/` 아래에 생성된 status/log 파일 경로가 표시됩니다. macOS에서는 백그라운드 삭제 성공 또는 실패를 알림으로 알려줍니다. 삭제가 끝날 때까지 기다리고 싶으면 `wt rm . --foreground`를 사용하세요.
 
+Herdr 안에서 실행하면 `wt rm`은 제거한 worktree에 연결된 Herdr workspace도 닫습니다. 백그라운드 제거에서는 작업 완료를 기다리지 않고 제거 작업이 시작되는 즉시 workspace를 닫습니다.
+
 다음 방법으로 worktree를 제거할 수 있습니다:
 - ID (기본값: 브랜치 이름, 예: `feature/issue-12`)
 - 레포 prefix가 포함된 전체 ID (예: `myrepo-feature/issue-12`)

--- a/README.ko.md
+++ b/README.ko.md
@@ -261,6 +261,10 @@ wt pr 123
 wt pr 123 --no-cd
 ```
 
+shell integration이 설치되어 있으면 `wt pr ` 뒤에서 `Tab`을 눌러 열린 GitHub PR
+목록을 completion할 수 있습니다. Zsh와 Fish는 completion 메뉴에 PR 제목, 작성자,
+브랜치, Draft 상태도 함께 표시합니다.
+
 이 명령은 다음을 수행합니다:
 1. GitHub CLI에서 PR의 base branch와 head branch를 조회
 2. 기존 worktree 중 그 PR head branch를 이미 체크아웃한 곳이 있는지 확인

--- a/README.ko.md
+++ b/README.ko.md
@@ -81,8 +81,9 @@ herdr plugin install leesangb/wt
 (`gh`)가 필요합니다.
 
 Herdr pane 안에서 `wt new`, `wt checkout`, `wt pr`을 실행하면 결과 checkout을
-Herdr worktree workspace로 즉시 열고 focus합니다. Herdr 밖에서는 기존 shell
-자동 `cd` 동작이 그대로 유지됩니다.
+Herdr worktree workspace로 즉시 열고 focus합니다. `--no-cd`를 사용하면 workspace를
+열되 focus는 이동하지 않습니다. Herdr 밖에서는 기존 shell 자동 `cd` 동작이 그대로
+유지됩니다.
 
 예를 들어 Herdr의 기본 새 worktree 단축키를 `wt` 흐름으로 교체할 수 있습니다:
 

--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ If the worktree has modified files or unpushed commits, `wt rm` asks for confirm
 
 When removing the worktree that contains your current directory, `wt rm` starts the removal in the background and immediately returns your shell to the main worktree. It prints the background task PID plus status and log file paths under the main worktree's `.wt/` directory. On macOS, Notification Center reports whether the background removal finished or failed. Use `wt rm . --foreground` if you want to wait for removal before returning.
 
+When run inside Herdr, `wt rm` also closes the Herdr workspace associated with the removed worktree. For background removal, the workspace closes as soon as the removal task starts; it does not wait for that task to finish.
+
 You can remove a worktree using:
 - ID (defaults to the branch name, e.g., `feature/issue-12`)
 - Full ID with repo prefix (e.g., `myrepo-feature/issue-12`)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ an authenticated GitHub CLI (`gh`).
 
 When `wt new`, `wt checkout`, or `wt pr` runs inside a Herdr pane, `wt`
 automatically opens the resulting checkout as a focused Herdr worktree workspace.
+Pass `--no-cd` to open the workspace without moving focus to it.
 Outside Herdr, the existing shell auto-`cd` behavior is unchanged.
 
 For example, replace Herdr's default new-worktree binding with the `wt` flow:

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ If the worktree has modified files or unpushed commits, `wt rm` asks for confirm
 
 When removing the worktree that contains your current directory, `wt rm` starts the removal in the background and immediately returns your shell to the main worktree. It prints the background task PID plus status and log file paths under the main worktree's `.wt/` directory. On macOS, Notification Center reports whether the background removal finished or failed. Use `wt rm . --foreground` if you want to wait for removal before returning.
 
-When run inside Herdr, `wt rm` also closes the Herdr workspace associated with the removed worktree. For background removal, the workspace closes as soon as the removal task starts; it does not wait for that task to finish.
+When run inside Herdr, `wt rm` also closes the Herdr workspace associated with the removed worktree. For background removal, the workspace closes as soon as the removal task starts; it does not wait for that task to finish. Set `herdr.closeWorkspaceOnRemove` to `false` to keep it open.
 
 You can remove a worktree using:
 - ID (defaults to the branch name, e.g., `feature/issue-12`)
@@ -369,10 +369,11 @@ Edit `.wt/settings.json` in your repository:
 - **scripts.pre**: Array of commands to run before creating worktree (runs in repo root)
 - **scripts.post**: Array of commands to run after creating worktree (runs in new worktree directory)
 - **scripts.postMode**: `async` (default) or `sync` for foreground execution
+- **herdr.closeWorkspaceOnRemove**: Close the associated Herdr workspace after `wt rm` (default: `true`)
 - **issue.pattern**: Optional JavaScript regular expression for extracting issue keys from branch names
 - **issue.url**: Optional issue tracker URL template. Use `$issue` where the extracted key should appear
 
-You can also add an optional `.wt/settings.local.json` for user- or machine-local overrides. `wt` loads `.wt/settings.json` first, then applies `.wt/settings.local.json` on top of it. Nested `copy.*`, `scripts.*`, and `issue.*` fields are merged, so you can override only `copy.exclude`, `scripts.postMode`, or `issue.url` without copying the rest of each object.
+You can also add an optional `.wt/settings.local.json` for user- or machine-local overrides. `wt` loads `.wt/settings.json` first, then applies `.wt/settings.local.json` on top of it. Nested `copy.*`, `scripts.*`, `herdr.*`, and `issue.*` fields are merged, so you can override only `copy.exclude`, `scripts.postMode`, `herdr.closeWorkspaceOnRemove`, or `issue.url` without copying the rest of each object.
 
 `copy.include` and `copy.exclude` are resolved relative to the repository root. A leading `./` is optional, so `./apps` and `apps` mean the same thing. If a pattern names a directory without `/**` (for example `.wt` or `apps/web`), `wt` treats it as the whole subtree for both include and exclude rules. `wt` only copies files that are untracked in the source repo, and it will not overwrite files already tracked in the newly created worktree. It always skips `.git`, `node_modules`, and directories currently ignored by `.gitignore`. Internal reserved files under `.wt/` such as `meta.json`, `.gitignore`, and async post-task state remain managed by `wt`.
 
@@ -397,6 +398,9 @@ Example `.wt/settings.local.json`:
   "baseBranch": "develop",
   "scripts": {
     "postMode": "sync"
+  },
+  "herdr": {
+    "closeWorkspaceOnRemove": false
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ wt pr 123
 wt pr 123 --no-cd
 ```
 
+With shell integration installed, press `Tab` after `wt pr ` to complete from
+open GitHub pull requests. Zsh and Fish also show the PR title, author, branch,
+and draft status in the completion menu.
+
 This command:
 1. Loads the PR's base branch and head branch from GitHub CLI
 2. Checks whether any existing worktree is already on that PR head branch

--- a/src/app/use-cases/list-open-pull-requests.ts
+++ b/src/app/use-cases/list-open-pull-requests.ts
@@ -1,0 +1,9 @@
+import { listOpenPullRequests } from "../../infra/github/cli.js";
+import { requireRepositoryContext } from "../repository-context.js";
+
+export async function listOpenPullRequestsForCompletion(
+  cwd: string = process.cwd()
+) {
+  const context = await requireRepositoryContext(cwd);
+  return listOpenPullRequests(context.repoRoot);
+}

--- a/src/app/use-cases/open-worktree-in-herdr.ts
+++ b/src/app/use-cases/open-worktree-in-herdr.ts
@@ -5,7 +5,8 @@ import {
 } from "../../infra/herdr/client.js";
 
 export async function openCreatedWorktreeInHerdr(
-  worktree: Pick<CreateWorktreeResult, "id" | "worktreePath">
+  worktree: Pick<CreateWorktreeResult, "id" | "worktreePath">,
+  options: { focus?: boolean } = {}
 ): Promise<OpenHerdrWorktreeResult> {
-  return openHerdrWorktree(worktree.worktreePath, worktree.id);
+  return openHerdrWorktree(worktree.worktreePath, worktree.id, options);
 }

--- a/src/app/use-cases/remove-worktree.ts
+++ b/src/app/use-cases/remove-worktree.ts
@@ -19,6 +19,11 @@ import {
 } from "../../infra/scripts/runner.js";
 import { ensureRemoveTaskArtifactsIgnored } from "../../infra/storage/settings-store.js";
 import type { WorktreeInfo } from "../../domain/worktree.js";
+import {
+  closeHerdrWorkspace,
+  findHerdrWorkspaceForWorktree,
+  type CloseHerdrWorkspaceResult,
+} from "../../infra/herdr/client.js";
 
 export interface RemoveWorktreeOptions {
   keepBranch?: boolean;
@@ -43,6 +48,8 @@ export interface RemoveWorktreeResult {
   worktree: WorktreeInfo;
   branchDeleted: boolean;
   relocatedToPath?: string;
+  herdrWorkspaceId?: string;
+  herdrError?: string;
 }
 
 export interface BackgroundRemoveWorktreeResult {
@@ -52,6 +59,14 @@ export interface BackgroundRemoveWorktreeResult {
   pid: number;
   statusFilePath: string;
   logFilePath: string;
+  herdrWorkspaceId?: string;
+  herdrError?: string;
+}
+
+export async function closeRemovedWorktreeInHerdr(
+  workspaceId: string | undefined
+): Promise<CloseHerdrWorkspaceResult> {
+  return closeHerdrWorkspace(workspaceId);
 }
 
 export class RemoveWorktreeError extends AppError {
@@ -284,6 +299,7 @@ export async function removeWorktree(
   cwd: string = process.cwd()
 ): Promise<RemoveWorktreeResult> {
   const { context, worktree } = await resolveRemovalTarget(target, cwd);
+  const herdr = await findHerdrWorkspaceForWorktree(worktree.path);
   const removalRoot = await resolveSafeRemovalRoot(context, worktree);
 
   await removeGitWorktree(removalRoot.gitRoot, worktree.path);
@@ -293,6 +309,8 @@ export async function removeWorktree(
       worktree,
       branchDeleted: false,
       relocatedToPath: removalRoot.relocatedToPath,
+      herdrWorkspaceId: herdr.workspaceId,
+      herdrError: herdr.error,
     };
   }
 
@@ -301,6 +319,8 @@ export async function removeWorktree(
       worktree,
       branchDeleted: false,
       relocatedToPath: removalRoot.relocatedToPath,
+      herdrWorkspaceId: herdr.workspaceId,
+      herdrError: herdr.error,
     };
   }
 
@@ -317,6 +337,8 @@ export async function removeWorktree(
     worktree,
     branchDeleted: true,
     relocatedToPath: removalRoot.relocatedToPath,
+    herdrWorkspaceId: herdr.workspaceId,
+    herdrError: herdr.error,
   };
 }
 
@@ -326,6 +348,7 @@ export async function removeCurrentWorktreeInBackground(
   cwd: string = process.cwd()
 ): Promise<BackgroundRemoveWorktreeResult> {
   const { context, worktree } = await resolveRemovalTarget(target, cwd);
+  const herdr = await findHerdrWorkspaceForWorktree(worktree.path);
 
   if (!isPathInside(worktree.path, context.cwd)) {
     throw new AppError(
@@ -385,5 +408,7 @@ export async function removeCurrentWorktreeInBackground(
     pid,
     statusFilePath,
     logFilePath,
+    herdrWorkspaceId: herdr.workspaceId,
+    herdrError: herdr.error,
   };
 }

--- a/src/app/use-cases/remove-worktree.ts
+++ b/src/app/use-cases/remove-worktree.ts
@@ -17,7 +17,10 @@ import {
   executeDetachedTask,
   shellEscapeSingle,
 } from "../../infra/scripts/runner.js";
-import { ensureRemoveTaskArtifactsIgnored } from "../../infra/storage/settings-store.js";
+import {
+  ensureRemoveTaskArtifactsIgnored,
+  loadSettings,
+} from "../../infra/storage/settings-store.js";
 import type { WorktreeInfo } from "../../domain/worktree.js";
 import {
   closeHerdrWorkspace,
@@ -299,7 +302,10 @@ export async function removeWorktree(
   cwd: string = process.cwd()
 ): Promise<RemoveWorktreeResult> {
   const { context, worktree } = await resolveRemovalTarget(target, cwd);
-  const herdr = await findHerdrWorkspaceForWorktree(worktree.path);
+  const settings = await loadSettings(context.repoRoot);
+  const herdr = settings.herdr.closeWorkspaceOnRemove
+    ? await findHerdrWorkspaceForWorktree(worktree.path)
+    : { attempted: false };
   const removalRoot = await resolveSafeRemovalRoot(context, worktree);
 
   await removeGitWorktree(removalRoot.gitRoot, worktree.path);
@@ -348,7 +354,10 @@ export async function removeCurrentWorktreeInBackground(
   cwd: string = process.cwd()
 ): Promise<BackgroundRemoveWorktreeResult> {
   const { context, worktree } = await resolveRemovalTarget(target, cwd);
-  const herdr = await findHerdrWorkspaceForWorktree(worktree.path);
+  const settings = await loadSettings(context.repoRoot);
+  const herdr = settings.herdr.closeWorkspaceOnRemove
+    ? await findHerdrWorkspaceForWorktree(worktree.path)
+    : { attempted: false };
 
   if (!isPathInside(worktree.path, context.cwd)) {
     throw new AppError(

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -71,6 +71,36 @@ function isShellAvailable(shell: string): boolean {
   }).status === 0;
 }
 
+function createFakeHerdr(worktreePath: string): {
+  env: Record<string, string>;
+  logPath: string;
+} {
+  const fakeDir = makeTempDir("wt-fake-herdr-");
+  const fakeHerdr = join(fakeDir, "herdr");
+  const logPath = join(fakeDir, "args.log");
+  writeFileSync(
+    fakeHerdr,
+    [
+      "#!/bin/sh",
+      `printf '%s\\n' "$*" >> "${logPath}"`,
+      'if [ "$1 $2" = "worktree list" ]; then',
+      `  printf '%s\\n' '{"result":{"worktrees":[{"path":"${worktreePath}","open_workspace_id":"w9"}]}}'`,
+      "fi",
+      "",
+    ].join("\n"),
+    { mode: 0o755 }
+  );
+
+  return {
+    env: {
+      HERDR_BIN_PATH: fakeHerdr,
+      HERDR_ENV: "1",
+      HERDR_WORKSPACE_ID: "w1",
+    },
+    logPath,
+  };
+}
+
 function readOutputValue(stdout: string, key: string): string {
   const line = stdout.split(/\r?\n/).find(entry => entry.startsWith(`${key}=`));
 
@@ -2178,6 +2208,52 @@ describe("cli e2e", () => {
     assertProcessSuccess(result.status, result.stderr, result.stdout);
     expect(result.stdout).not.toContain("Remove this worktree anyway? [y/N]");
     expect(existsSync(worktreePath)).toBeFalse();
+  });
+
+  test("closes the Herdr workspace after removing its worktree", async () => {
+    const repo = await createTestRepo();
+    const worktreeId = "rmherdr123";
+    const branchName = "feature-rm-herdr";
+    const worktreePath = getWorktreePath(repo, worktreeId);
+
+    runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
+    const herdr = createFakeHerdr(worktreePath);
+    const result = runCliCapture(
+      ["remove", worktreeId, "--keep-branch"],
+      repo.repoRoot,
+      { env: herdr.env }
+    );
+
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+    expect(readFileSync(herdr.logPath, "utf-8")).toContain(
+      "workspace close w9"
+    );
+  });
+
+  test("closes the Herdr workspace as soon as background removal starts", async () => {
+    if (!isShellAvailable("bash")) {
+      return;
+    }
+
+    const repo = await createTestRepo();
+    const worktreeId = "rmherdrbg123";
+    const branchName = "feature-rm-herdr-bg";
+    const worktreePath = getWorktreePath(repo, worktreeId);
+
+    runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
+    const herdr = createFakeHerdr(worktreePath);
+    const result = runWrappedBashSession(
+      repo.repoRoot,
+      [`builtin cd "${worktreePath}"`, `wt rm ${worktreeId} --keep-branch`],
+      herdr.env
+    );
+
+    assertProcessSuccess(result.processStatus, result.stderr, result.stdout);
+    expect(result.stdout).toContain("Started background removal");
+    expect(readFileSync(herdr.logPath, "utf-8")).toContain(
+      "workspace close w9"
+    );
+    await waitForRemoveTaskStatus(repo.repoRoot, worktreeId, "done");
   });
 
   test(

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -1106,6 +1106,41 @@ describe("cli e2e", () => {
     expect(readFileSync(logPath, "utf8")).toContain(
       `worktree open --workspace w1 --path ${getWorktreePath(repo, branchName)}`
     );
+    expect(readFileSync(logPath, "utf8")).toContain("--focus");
+  });
+
+  test("opens a new Herdr workspace without focusing it when --no-cd is set", async () => {
+    const repo = await createTestRepo();
+    const branchName = "feature/herdr-no-focus";
+    const fakeDir = makeTempDir("wt-herdr-");
+    const fakeHerdr = join(fakeDir, "herdr");
+    const logPath = join(fakeDir, "args.log");
+    writeFileSync(
+      fakeHerdr,
+      [
+        "#!/bin/sh",
+        `printf '%s\\n' "$*" > "${logPath}"`,
+        "printf '%s\\n' '{\"result\":{}}'",
+        "",
+      ].join("\n"),
+      { mode: 0o755 }
+    );
+
+    const result = runCliCapture(
+      ["new", branchName, "--no-push", "--no-cd"],
+      repo.repoRoot,
+      {
+        env: {
+          HERDR_BIN_PATH: fakeHerdr,
+          HERDR_ENV: "1",
+          HERDR_WORKSPACE_ID: "w1",
+        },
+      }
+    );
+
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+    expect(readFileSync(logPath, "utf8")).toContain("--no-focus");
+    expect(readFileSync(logPath, "utf8")).not.toContain("--focus");
   });
 
   test("prints a stable JSON result when checking out a local branch", async () => {

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -337,7 +337,7 @@ function createFakeGithubEnv(
         "  exit 1",
         "fi",
         'if [ "$1" = "pr" ] && [ "${2:-}" = "list" ]; then',
-        `  printf '%s\\n' '[{"number":${prNumber},"url":"${prUrl}","headRefName":"${headBranch}"}]'`,
+        `  printf '%s\\n' '[{"number":${prNumber},"url":"${prUrl}","title":"Fix login: failure","author":{"login":"sangbin"},"headRefName":"${headBranch}","isDraft":true}]'`,
         "  exit 0",
         "fi",
         'if [ "$1" = "pr" ] && [ "${2:-}" = "checkout" ]; then',
@@ -1178,6 +1178,25 @@ describe("cli e2e", () => {
       branch: headBranch,
       reusedExisting: false,
     });
+  });
+
+  test("lists open pull requests for shell completion", async () => {
+    const repo = await createTestRepo();
+    const ghLogPath = join(repo.repoRoot, "gh-completion.log");
+    const result = runCliCapture(["_complete-pr", "zsh"], repo.repoRoot, {
+      env: createFakeGithubEnv({
+        headBranch: "feature/login-fix",
+        logPath: ghLogPath,
+      }),
+    });
+
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+    expect(result.stdout.trim()).toBe(
+      "123:Draft | Fix login failure | @sangbin | feature/login-fix"
+    );
+    expect(readFileSync(ghLogPath, "utf-8")).toContain(
+      "pr list --state open --limit 100 --json number,title,author,headRefName,isDraft"
+    );
   });
 
   test("navigates to a worktree by branch name via the bash wrapper", async () => {

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -2230,6 +2230,28 @@ describe("cli e2e", () => {
     );
   });
 
+  test("keeps the Herdr workspace open when configured", async () => {
+    const repo = await createTestRepo();
+    const worktreeId = "rmherdrkeep123";
+    const branchName = "feature-rm-herdr-keep";
+    const worktreePath = getWorktreePath(repo, worktreeId);
+
+    runCli(["new", branchName, "--id", worktreeId, "--no-cd"], repo.repoRoot);
+    writeFileSync(
+      join(repo.repoRoot, ".wt", "settings.local.json"),
+      JSON.stringify({ herdr: { closeWorkspaceOnRemove: false } })
+    );
+    const herdr = createFakeHerdr(worktreePath);
+    const result = runCliCapture(
+      ["remove", worktreeId, "--keep-branch"],
+      repo.repoRoot,
+      { env: herdr.env }
+    );
+
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+    expect(existsSync(herdr.logPath)).toBeFalse();
+  });
+
   test("closes the Herdr workspace as soon as background removal starts", async () => {
     if (!isShellAvailable("bash")) {
       return;

--- a/src/commands/checkout.ts
+++ b/src/commands/checkout.ts
@@ -16,7 +16,9 @@ export async function checkoutCommand(
 ): Promise<void> {
   await runCommand(async () => {
     const result = await createBranchWorktree(branchName);
-    const herdr = await openCreatedWorktreeInHerdr(result);
+    const herdr = await openCreatedWorktreeInHerdr(result, {
+      focus: options.cd !== false,
+    });
 
     if (herdr.error) {
       console.error(chalk.yellow(`Warning: Could not open in Herdr: ${herdr.error}`));

--- a/src/commands/complete-pr.ts
+++ b/src/commands/complete-pr.ts
@@ -1,0 +1,35 @@
+import { AppError } from "../app/errors.js";
+import { listOpenPullRequestsForCompletion } from "../app/use-cases/list-open-pull-requests.js";
+import { runCommand } from "../cli/command-runtime.js";
+
+type CompletionFormat = "bash" | "zsh" | "fish";
+
+const COMPLETION_FORMATS = new Set<CompletionFormat>(["bash", "zsh", "fish"]);
+
+function sanitizeDescription(value: string): string {
+  return value.replaceAll(/[\r\n\t:]+/g, " ").replaceAll(/\s+/g, " ").trim();
+}
+
+export async function completePrCommand(format: string): Promise<void> {
+  await runCommand(async () => {
+    if (!COMPLETION_FORMATS.has(format as CompletionFormat)) {
+      throw new AppError(
+        `Unsupported completion format "${format}". Expected one of: bash, zsh, fish.`
+      );
+    }
+
+    const pullRequests = await listOpenPullRequestsForCompletion();
+
+    for (const pullRequest of pullRequests) {
+      const metadata = [
+        pullRequest.isDraft ? "Draft" : undefined,
+        sanitizeDescription(pullRequest.title),
+        `@${sanitizeDescription(pullRequest.author)}`,
+        sanitizeDescription(pullRequest.headRefName),
+      ].filter((value): value is string => Boolean(value));
+      const separator = format === "fish" ? "\t" : ":";
+
+      console.log(`${pullRequest.number}${separator}${metadata.join(" | ")}`);
+    }
+  });
+}

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -22,7 +22,9 @@ export async function newCommand(
       console.log(chalk.blue("Fetching latest changes..."));
     }
     const result = await createWorktree(branchName, options);
-    const herdr = await openCreatedWorktreeInHerdr(result);
+    const herdr = await openCreatedWorktreeInHerdr(result, {
+      focus: options.cd !== false,
+    });
 
     if (herdr.error) {
       console.error(chalk.yellow(`Warning: Could not open in Herdr: ${herdr.error}`));

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -16,7 +16,9 @@ export async function prCommand(
 ): Promise<void> {
   await runCommand(async () => {
     const result = await createPrWorktree(pullRequestNumber);
-    const herdr = await openCreatedWorktreeInHerdr(result);
+    const herdr = await openCreatedWorktreeInHerdr(result, {
+      focus: options.cd !== false,
+    });
 
     if (herdr.error) {
       console.error(chalk.yellow(`Warning: Could not open in Herdr: ${herdr.error}`));

--- a/src/commands/remove-shared.ts
+++ b/src/commands/remove-shared.ts
@@ -4,6 +4,7 @@ import { AppError } from "../app/errors.js";
 import { getWorktreeBranchLabel } from "../domain/worktree.js";
 import {
   type BackgroundRemoveWorktreeResult,
+  closeRemovedWorktreeInHerdr,
   inspectRemoveWorktree,
   removeCurrentWorktreeInBackground,
   RemoveWorktreeError,
@@ -293,6 +294,7 @@ export async function removeSingleWorktree(
   ) {
     const result = await removeCurrentWorktreeInBackground(id, options);
     logBackgroundRemovalResult(result);
+    await closeHerdrAfterRemoval(result);
     return "removed";
   }
 
@@ -311,5 +313,25 @@ export async function removeSingleWorktree(
     }
   );
   logRemovalResult(result);
+  await closeHerdrAfterRemoval(result);
   return "removed";
+}
+
+async function closeHerdrAfterRemoval(result: {
+  herdrWorkspaceId?: string;
+  herdrError?: string;
+}): Promise<void> {
+  if (result.herdrError) {
+    console.error(
+      chalk.yellow(`Warning: Could not find Herdr workspace: ${result.herdrError}`)
+    );
+    return;
+  }
+
+  const herdr = await closeRemovedWorktreeInHerdr(result.herdrWorkspaceId);
+  if (herdr.error) {
+    console.error(
+      chalk.yellow(`Warning: Could not close Herdr workspace: ${herdr.error}`)
+    );
+  }
 }

--- a/src/domain/settings.test.ts
+++ b/src/domain/settings.test.ts
@@ -98,6 +98,9 @@ describe("normalizeSettings", () => {
         post: ["pnpm install"],
         postMode: "async",
       },
+      herdr: {
+        closeWorkspaceOnRemove: true,
+      },
     });
   });
 
@@ -122,6 +125,9 @@ describe("normalizeSettings", () => {
         post: [],
         postMode: "async",
       },
+      herdr: {
+        closeWorkspaceOnRemove: true,
+      },
     });
   });
 
@@ -136,6 +142,18 @@ describe("normalizeSettings", () => {
     ).toEqual({
       pattern: "[A-Z]+-\\d+",
       url: "https://myissues.com/$issue",
+    });
+  });
+
+  test("allows automatic Herdr workspace closing to be disabled", () => {
+    expect(
+      normalizeSettings({
+        herdr: {
+          closeWorkspaceOnRemove: false,
+        },
+      }).herdr
+    ).toEqual({
+      closeWorkspaceOnRemove: false,
     });
   });
 
@@ -156,6 +174,9 @@ describe("normalizeSettings", () => {
         pre: [],
         post: [],
         postMode: "async",
+      },
+      herdr: {
+        closeWorkspaceOnRemove: true,
       },
     });
   });

--- a/src/domain/settings.ts
+++ b/src/domain/settings.ts
@@ -16,22 +16,28 @@ export interface WtIssueSettings {
   url: string;
 }
 
+export interface WtHerdrSettings {
+  closeWorkspaceOnRemove: boolean;
+}
+
 export interface WtSettings {
   worktreeDir: string;
   baseBranch: string;
   pushRemote: boolean;
   copy: WtCopySettings;
   scripts: WtScriptsSettings;
+  herdr: WtHerdrSettings;
   issue?: WtIssueSettings;
 }
 
 export type WtCopySettingsInput = string[] | Partial<WtCopySettings>;
 
 export type WtSettingsInput = Partial<
-  Omit<WtSettings, "copy" | "scripts" | "issue">
+  Omit<WtSettings, "copy" | "scripts" | "herdr" | "issue">
 > & {
   copy?: WtCopySettingsInput;
   scripts?: Partial<WtScriptsSettings>;
+  herdr?: Partial<WtHerdrSettings>;
   issue?: Partial<WtIssueSettings>;
 };
 
@@ -47,6 +53,9 @@ export const DEFAULT_WT_SETTINGS: WtSettings = {
     pre: [],
     post: [],
     postMode: "async",
+  },
+  herdr: {
+    closeWorkspaceOnRemove: true,
   },
 };
 
@@ -110,12 +119,20 @@ export function mergeSettingsInputs(
           ...override?.issue,
         }
       : undefined;
+  const mergedHerdr =
+    base?.herdr || override?.herdr
+      ? {
+          ...base?.herdr,
+          ...override?.herdr,
+        }
+      : undefined;
 
   return {
     ...base,
     ...override,
     ...(mergedCopy ? { copy: mergedCopy } : {}),
     ...(mergedScripts ? { scripts: mergedScripts } : {}),
+    ...(mergedHerdr ? { herdr: mergedHerdr } : {}),
     ...(mergedIssue ? { issue: mergedIssue } : {}),
   };
 }
@@ -139,6 +156,11 @@ export function normalizeSettings(
       post: input?.scripts?.post ?? DEFAULT_WT_SETTINGS.scripts.post,
       postMode:
         input?.scripts?.postMode ?? DEFAULT_WT_SETTINGS.scripts.postMode,
+    },
+    herdr: {
+      closeWorkspaceOnRemove:
+        input?.herdr?.closeWorkspaceOnRemove ??
+        DEFAULT_WT_SETTINGS.herdr.closeWorkspaceOnRemove,
     },
     ...(issueInput ? { issue: issueInput } : {}),
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { prCommand } from "./commands/pr.js";
 import { checkoutCommand } from "./commands/checkout.js";
 import { shellInstallCommand } from "./commands/shell.js";
 import { uninstallCommand } from "./commands/uninstall.js";
+import { completePrCommand } from "./commands/complete-pr.js";
 import pkg from "../package.json";
 
 const program = new Command();
@@ -88,6 +89,10 @@ program
   .option("--no-cd", "Skip changing directory (for direct binary usage)")
   .option("--json", "Output the worktree result as JSON")
   .action(prCommand);
+
+program
+  .command("_complete-pr <format>", { hidden: true })
+  .action(completePrCommand);
 
 program
   .command("checkout <branch-name>")

--- a/src/infra/github/cli.ts
+++ b/src/infra/github/cli.ts
@@ -21,6 +21,14 @@ export interface PullRequestLink {
   url: string;
 }
 
+export interface OpenPullRequestSummary {
+  author: string;
+  headRefName: string;
+  isDraft: boolean;
+  number: string;
+  title: string;
+}
+
 interface PullRequestListEntry {
   headRefName: string;
   number: number;
@@ -192,6 +200,66 @@ export async function listPullRequestLinks(
       (entry): entry is [string, PullRequestLink] => entry[1] !== null
     )
   );
+}
+
+export async function listOpenPullRequests(
+  repoRoot: string
+): Promise<OpenPullRequestSummary[]> {
+  const result = runGithubCommand(
+    [
+      "pr",
+      "list",
+      "--state",
+      "open",
+      "--limit",
+      "100",
+      "--json",
+      "number,title,author,headRefName,isDraft",
+    ],
+    repoRoot
+  );
+
+  if (result.status !== 0) {
+    return [];
+  }
+
+  let entries: Array<{
+    author?: { login?: string };
+    headRefName?: string;
+    isDraft?: boolean;
+    number?: number;
+    title?: string;
+  }>;
+
+  try {
+    entries = JSON.parse(result.stdout) as typeof entries;
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  return entries.flatMap((entry) => {
+    if (
+      typeof entry.number !== "number" ||
+      !entry.title ||
+      !entry.headRefName
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        author: entry.author?.login ?? "unknown",
+        headRefName: entry.headRefName,
+        isDraft: entry.isDraft === true,
+        number: String(entry.number),
+        title: entry.title,
+      },
+    ];
+  });
 }
 
 export async function checkoutPullRequest(

--- a/src/infra/herdr/client.test.ts
+++ b/src/infra/herdr/client.test.ts
@@ -3,7 +3,7 @@ import { openHerdrWorktree } from "./client.js";
 
 describe("Herdr client", () => {
   test("does nothing outside a Herdr-managed pane", async () => {
-    expect(await openHerdrWorktree("/worktree", "feature", {})).toEqual({
+    expect(await openHerdrWorktree("/worktree", "feature", {}, {})).toEqual({
       attempted: false,
       opened: false,
     });

--- a/src/infra/herdr/client.ts
+++ b/src/infra/herdr/client.ts
@@ -1,4 +1,6 @@
 import { spawn } from "bun";
+import { realpathSync } from "fs";
+import { resolve } from "path";
 
 export interface HerdrEnvironment {
   [key: string]: string | undefined;
@@ -13,12 +15,38 @@ export interface OpenHerdrWorktreeResult {
   error?: string;
 }
 
+export interface FindHerdrWorkspaceResult {
+  attempted: boolean;
+  workspaceId?: string;
+  error?: string;
+}
+
+export interface CloseHerdrWorkspaceResult {
+  attempted: boolean;
+  closed: boolean;
+  error?: string;
+}
+
+function isHerdrEnvironment(
+  env: HerdrEnvironment
+): env is HerdrEnvironment & { HERDR_WORKSPACE_ID: string } {
+  return env.HERDR_ENV === "1" && Boolean(env.HERDR_WORKSPACE_ID);
+}
+
+function normalizePath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
 export async function openHerdrWorktree(
   path: string,
   label: string,
   env: HerdrEnvironment = process.env
 ): Promise<OpenHerdrWorktreeResult> {
-  if (env.HERDR_ENV !== "1" || !env.HERDR_WORKSPACE_ID) {
+  if (!isHerdrEnvironment(env)) {
     return { attempted: false, opened: false };
   }
 
@@ -54,4 +82,78 @@ export async function openHerdrWorktree(
   }
 
   return { attempted: true, opened: true };
+}
+
+export async function findHerdrWorkspaceForWorktree(
+  path: string,
+  env: HerdrEnvironment = process.env
+): Promise<FindHerdrWorkspaceResult> {
+  if (!isHerdrEnvironment(env)) {
+    return { attempted: false };
+  }
+
+  const herdr = env.HERDR_BIN_PATH ?? "herdr";
+  const proc = spawn([herdr, "worktree", "list", "--cwd", path, "--json"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    return {
+      attempted: true,
+      error: stderr.trim() || `herdr exited with code ${exitCode}`,
+    };
+  }
+
+  try {
+    const response = JSON.parse(stdout) as {
+      result?: {
+        worktrees?: Array<{ path?: string; open_workspace_id?: string }>;
+      };
+    };
+    const normalizedPath = normalizePath(path);
+    const workspaceId = response.result?.worktrees?.find(
+      (worktree) =>
+        worktree.path && normalizePath(worktree.path) === normalizedPath
+    )?.open_workspace_id;
+
+    return { attempted: true, ...(workspaceId ? { workspaceId } : {}) };
+  } catch {
+    return { attempted: true, error: "herdr returned invalid JSON" };
+  }
+}
+
+export async function closeHerdrWorkspace(
+  workspaceId: string | undefined,
+  env: HerdrEnvironment = process.env
+): Promise<CloseHerdrWorkspaceResult> {
+  if (!workspaceId || !isHerdrEnvironment(env)) {
+    return { attempted: false, closed: false };
+  }
+
+  const herdr = env.HERDR_BIN_PATH ?? "herdr";
+  const proc = spawn([herdr, "workspace", "close", workspaceId], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    return {
+      attempted: true,
+      closed: false,
+      error: stderr.trim() || `herdr exited with code ${exitCode}`,
+    };
+  }
+
+  return { attempted: true, closed: true };
 }

--- a/src/infra/herdr/client.ts
+++ b/src/infra/herdr/client.ts
@@ -15,6 +15,10 @@ export interface OpenHerdrWorktreeResult {
   error?: string;
 }
 
+export interface OpenHerdrWorktreeOptions {
+  focus?: boolean;
+}
+
 export interface FindHerdrWorkspaceResult {
   attempted: boolean;
   workspaceId?: string;
@@ -44,6 +48,7 @@ function normalizePath(path: string): string {
 export async function openHerdrWorktree(
   path: string,
   label: string,
+  options: OpenHerdrWorktreeOptions = {},
   env: HerdrEnvironment = process.env
 ): Promise<OpenHerdrWorktreeResult> {
   if (!isHerdrEnvironment(env)) {
@@ -62,7 +67,7 @@ export async function openHerdrWorktree(
       path,
       "--label",
       label,
-      "--focus",
+      options.focus === false ? "--no-focus" : "--focus",
       "--json",
     ],
     { stdout: "pipe", stderr: "pipe" }

--- a/src/infra/shell/installer.test.ts
+++ b/src/infra/shell/installer.test.ts
@@ -90,7 +90,9 @@ describe("shell installer", () => {
     const wrapper = renderShellWrapper("fish", "/tmp/wt bin");
 
     expect(wrapper).toContain('function __wt_complete_cd');
+    expect(wrapper).toContain('function __wt_complete_pr');
     expect(wrapper).toContain('"/tmp/wt bin" list --completion fish 2>/dev/null');
+    expect(wrapper).toContain('"/tmp/wt bin" _complete-pr fish 2>/dev/null');
     expect(wrapper).toContain('complete -c wt -n "__fish_seen_subcommand_from cd" -a "(__wt_complete_cd)" -f');
   });
 

--- a/src/infra/shell/installer.ts
+++ b/src/infra/shell/installer.ts
@@ -174,6 +174,13 @@ _wt_completion() {
         COMPREPLY=($(compgen -W "$ids" -- "\${COMP_WORDS[$COMP_CWORD]}"))
       fi
       ;;
+    pr)
+      if [ $COMP_CWORD -eq 2 ]; then
+        local items=$(${renderedCommand} _complete-pr bash 2>/dev/null)
+        local numbers=$(echo "$items" | cut -d: -f1)
+        COMPREPLY=($(compgen -W "$numbers" -- "\${COMP_WORDS[2]}"))
+      fi
+      ;;
   esac
 }
 
@@ -247,6 +254,10 @@ _wt_completion() {
           suggestions=("\${(@f)$(${renderedCommand} list --completion zsh --exclude-main-worktree 2>/dev/null)}")
           _describe 'worktree' suggestions
           ;;
+        pr)
+          suggestions=("\${(@f)$(${renderedCommand} _complete-pr zsh 2>/dev/null)}")
+          _describe 'pull request' suggestions
+          ;;
       esac
       ;;
   esac
@@ -293,8 +304,13 @@ function __wt_complete_remove
     ${renderedCommand} list --completion fish --exclude-main-worktree 2>/dev/null
 end
 
+function __wt_complete_pr
+    ${renderedCommand} _complete-pr fish 2>/dev/null
+end
+
 complete -c wt -n "__fish_seen_subcommand_from cd" -a "(__wt_complete_cd)" -f
 complete -c wt -n "__fish_seen_subcommand_from rm remove" -a "(__wt_complete_remove)" -f
+complete -c wt -n "__fish_seen_subcommand_from pr" -a "(__wt_complete_pr)" -f
 `;
 }
 

--- a/src/infra/storage/settings-store.test.ts
+++ b/src/infra/storage/settings-store.test.ts
@@ -110,6 +110,9 @@ describe("settings store", () => {
         post: [],
         postMode: "async",
       },
+      herdr: {
+        closeWorkspaceOnRemove: true,
+      },
     });
   });
 
@@ -135,6 +138,9 @@ describe("settings store", () => {
         pre: [],
         post: [],
         postMode: "async",
+      },
+      herdr: {
+        closeWorkspaceOnRemove: true,
       },
     });
   });
@@ -180,6 +186,9 @@ describe("settings store", () => {
         post: ["bun install"],
         postMode: "sync",
       },
+      herdr: {
+        closeWorkspaceOnRemove: true,
+      },
     });
   });
 
@@ -207,6 +216,9 @@ describe("settings store", () => {
         pre: [],
         post: ["pnpm install"],
         postMode: "async",
+      },
+      herdr: {
+        closeWorkspaceOnRemove: true,
       },
     });
   });
@@ -241,6 +253,9 @@ describe("settings store", () => {
         pre: [],
         post: [],
         postMode: "async",
+      },
+      herdr: {
+        closeWorkspaceOnRemove: true,
       },
     });
   });

--- a/src/utils/shell-wrapper.test.ts
+++ b/src/utils/shell-wrapper.test.ts
@@ -132,7 +132,7 @@ function runWrapper(
 
 function runCompletion(
   shellCase: ShellCase,
-  subcommand: "cd" | "rm" | "remove",
+  subcommand: "cd" | "pr" | "rm" | "remove",
   precedingArgs: string[] = []
 ): CompletionRunResult {
   const tempDir = mkdtempSync(join(tmpdir(), "wt-shell-completion-"));
@@ -163,6 +163,13 @@ function runCompletion(
         "      fi",
         "      ;;",
         "  esac",
+        "fi",
+        'if [ "$1" = "_complete-pr" ]; then',
+        '  if [ "$2" = "fish" ]; then',
+        '    printf \'%s\\n\' "142\tFix login | @sangbin | feature/login" "77\tDraft | Update docs | @lee | docs/update"',
+        "  else",
+        '    printf \'%s\\n\' "142:Fix login | @sangbin | feature/login" "77:Draft | Update docs | @lee | docs/update"',
+        "  fi",
         "fi",
         "",
       ].join("\n"),
@@ -442,6 +449,14 @@ describe("shell wrappers", () => {
       expect(result.suggestions).not.toContain("main");
       expect(result.suggestions).toContain("demo");
       expect(result.suggestions).toContain("sample");
+    });
+
+    test(`${shellCase.scriptName} completes open pull request numbers for pr`, () => {
+      const result = runCompletion(shellCase, "pr");
+
+      assertCompletionProcess(result);
+      expect(result.suggestions).toContain("142");
+      expect(result.suggestions).toContain("77");
     });
   }
 });


### PR DESCRIPTION
## Summary
- close the associated Herdr workspace when `wt rm` starts, with `herdr.closeWorkspaceOnRemove` as an opt-out
- preserve the current Herdr focus when `--no-cd` opens a worktree
- complete `wt pr` from open GitHub pull requests in Bash, Zsh, and Fish
- release these changes as a patch

## Verification
- `bun run typecheck`
- `bun test` (216 tests)