### PR TITLE
refactor: deepen worktree creation lifecycle

### DIFF
--- a/src/app/use-cases/create-branch-worktree.ts
+++ b/src/app/use-cases/create-branch-worktree.ts
@@ -1,26 +1,10 @@
-import { createWorktreeMeta } from "../../domain/worktree.js";
 import {
-  createScriptEnvironment,
-  ensureWorktreeBaseDir,
-  resolveFreshWorktreePath,
-  runPostCreationScripts,
-  runPreCreationScripts,
-  resolveUniqueWorktreeId,
+  createPreparedWorktree,
   type CreateWorktreeResult,
 } from "../worktree-creation.js";
-import { copyConfiguredPaths } from "../worktree-copy.js";
 import { requireRepositoryContext } from "../repository-context.js";
 import { loadWorktreeInfos } from "../worktree-catalog.js";
-import {
-  loadSettings,
-  resolveWorktreeDir,
-} from "../../infra/storage/settings-store.js";
-import {
-  attachGitWorktree,
-  localBranchExists,
-} from "../../infra/git/worktree-repository.js";
-import { getCommitHash, getMergeBase } from "../../infra/git/status.js";
-import { writeWorktreeMeta } from "../../infra/storage/worktree-meta-store.js";
+import { localBranchExists } from "../../infra/git/worktree-repository.js";
 import { AppError } from "../errors.js";
 
 function normalizeBranchName(branchName: string): string {
@@ -62,65 +46,10 @@ export async function createBranchWorktree(
     );
   }
 
-  const settings = await loadSettings(context.repoRoot);
-  const { id, idAdjustedFrom } = resolveUniqueWorktreeId(
-    normalizedBranchName,
-    worktrees.map((worktree) => worktree.id)
-  );
-  const fullId = `${context.repoName}-${id}`;
-  const worktreeBaseDir = resolveWorktreeDir(
-    settings.worktreeDir,
-    context.repoRoot
-  );
-
-  ensureWorktreeBaseDir(worktreeBaseDir);
-
-  const worktreePath = resolveFreshWorktreePath(
-    worktreeBaseDir,
-    context.repoName,
-    id
-  );
-  const baseBranch = settings.baseBranch;
-  const baseCommit =
-    (await getMergeBase(
-      context.repoRoot,
-      normalizedBranchName,
-      baseBranch
-    )) || (await getCommitHash(context.repoRoot, baseBranch));
-  const scriptEnv = createScriptEnvironment(
-    context.repoRoot,
-    worktreePath,
-    id,
-    fullId,
-    normalizedBranchName
-  );
-
-  await runPreCreationScripts(settings, context.repoRoot, scriptEnv);
-  await attachGitWorktree(context.repoRoot, worktreePath, normalizedBranchName);
-  await copyConfiguredPaths(settings, context.repoRoot, worktreePath);
-
-  await writeWorktreeMeta(
-    worktreePath,
-    createWorktreeMeta(baseBranch, baseCommit, undefined, {
-      id,
-      fullId,
-    })
-  );
-
-  const postScriptResult = await runPostCreationScripts(
-    settings,
-    worktreePath,
-    scriptEnv
-  );
-
-  return {
+  return createPreparedWorktree({
+    kind: "existing-branch",
+    context,
     branchName: normalizedBranchName,
-    id,
-    fullId,
-    worktreePath,
-    baseBranch,
-    baseCommit,
-    idAdjustedFrom,
-    ...postScriptResult,
-  };
+    existingIds: worktrees.map((worktree) => worktree.id),
+  });
 }

--- a/src/app/use-cases/create-pr-worktree.ts
+++ b/src/app/use-cases/create-pr-worktree.ts
@@ -1,38 +1,13 @@
-import { createWorktreeMeta } from "../../domain/worktree.js";
 import {
-  createScriptEnvironment,
-  ensureWorktreeBaseDir,
-  resolveFreshWorktreePath,
-  runPostCreationScripts,
-  runPreCreationScripts,
-  resolveUniqueWorktreeId,
+  createPreparedWorktree,
   type CreateWorktreeResult,
 } from "../worktree-creation.js";
-import { copyConfiguredPaths } from "../worktree-copy.js";
 import { requireRepositoryContext } from "../repository-context.js";
 import { loadWorktreeInfos } from "../worktree-catalog.js";
 import {
-  loadSettings,
-  resolveWorktreeDir,
-} from "../../infra/storage/settings-store.js";
-import {
-  checkoutPullRequest,
   ensureGithubCliReady,
   getPullRequestInfo,
 } from "../../infra/github/cli.js";
-import {
-  createDetachedGitWorktree,
-  deleteBranch,
-  fetchRemote,
-  fetchRemoteBranch,
-  localBranchExists,
-  removeGitWorktree,
-} from "../../infra/git/worktree-repository.js";
-import {
-  isRefAncestor,
-  resolveCommitHash,
-} from "../../infra/git/status.js";
-import { writeWorktreeMeta } from "../../infra/storage/worktree-meta-store.js";
 import { AppError } from "../errors.js";
 
 function normalizePullRequestNumber(pullRequestNumber: string): string {
@@ -45,63 +20,22 @@ function normalizePullRequestNumber(pullRequestNumber: string): string {
   return value;
 }
 
-function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return String(error);
-}
-
-async function resolvePrBaseCommit(
-  repoRoot: string,
-  baseBranch: string
-): Promise<string> {
-  const initialResolution = await resolveCommitHash(repoRoot, [
-    baseBranch,
-    `origin/${baseBranch}`,
-    `refs/remotes/origin/${baseBranch}`,
-  ]);
-
-  if (initialResolution) {
-    return initialResolution.commitHash;
-  }
-
-  await fetchRemoteBranch(repoRoot, baseBranch);
-
-  const fetchedResolution = await resolveCommitHash(repoRoot, [
-    `origin/${baseBranch}`,
-    `refs/remotes/origin/${baseBranch}`,
-    baseBranch,
-  ]);
-
-  if (fetchedResolution) {
-    return fetchedResolution.commitHash;
-  }
-
-  throw new AppError(
-    `Could not resolve PR base branch ${baseBranch} from origin. Fetch it manually or confirm the branch still exists.`
-  );
-}
-
 export async function createPrWorktree(
   pullRequestNumber: string,
   cwd: string = process.cwd()
 ): Promise<CreateWorktreeResult> {
   const prNumber = normalizePullRequestNumber(pullRequestNumber);
-  const preferredId = `pr-${prNumber}`;
   const context = await requireRepositoryContext(cwd);
   await ensureGithubCliReady(context.repoRoot);
-  const pullRequestInfo = await getPullRequestInfo(context.repoRoot, prNumber);
-  const branchName = pullRequestInfo.headRefName;
+  const pullRequest = await getPullRequestInfo(context.repoRoot, prNumber);
   const worktrees = await loadWorktreeInfos(context);
   const existingWorktree = worktrees.find(
-    (worktree) => worktree.branch === branchName
+    (worktree) => worktree.branch === pullRequest.headRefName
   );
 
   if (existingWorktree) {
     return {
-      branchName,
+      branchName: pullRequest.headRefName,
       id: existingWorktree.id,
       fullId: existingWorktree.fullId,
       worktreePath: existingWorktree.path,
@@ -111,120 +45,10 @@ export async function createPrWorktree(
     };
   }
 
-  const settings = await loadSettings(context.repoRoot);
-  const { id, idAdjustedFrom } = resolveUniqueWorktreeId(
-    preferredId,
-    worktrees.map((worktree) => worktree.id)
-  );
-  const fullId = `${context.repoName}-${id}`;
-  const worktreeBaseDir = resolveWorktreeDir(
-    settings.worktreeDir,
-    context.repoRoot
-  );
-
-  ensureWorktreeBaseDir(worktreeBaseDir);
-  await fetchRemote(context.repoRoot);
-
-  const baseBranch = pullRequestInfo.baseRefName;
-  const baseCommit = await resolvePrBaseCommit(context.repoRoot, baseBranch);
-  const branchExistedBeforeCheckout = await localBranchExists(
-    context.repoRoot,
-    branchName
-  );
-
-  if (
-    branchExistedBeforeCheckout &&
-    !(await isRefAncestor(
-      context.repoRoot,
-      branchName,
-      pullRequestInfo.headRefOid
-    ))
-  ) {
-    throw new AppError(
-      `Local branch ${branchName} already exists but diverges from PR #${prNumber}. Refusing to reset it automatically; delete or rename the local branch, or merge/rebase it manually first.`
-    );
-  }
-
-  const worktreePath = resolveFreshWorktreePath(
-    worktreeBaseDir,
-    context.repoName,
-    id
-  );
-  const scriptEnv = createScriptEnvironment(
-    context.repoRoot,
-    worktreePath,
-    id,
-    fullId,
-    branchName
-  );
-
-  await runPreCreationScripts(settings, context.repoRoot, scriptEnv);
-  await createDetachedGitWorktree(
-    context.repoRoot,
-    worktreePath,
-    baseCommit
-  );
-
-  try {
-    await checkoutPullRequest(worktreePath, prNumber);
-  } catch (error) {
-    const cleanupErrors: string[] = [];
-
-    try {
-      await removeGitWorktree(context.repoRoot, worktreePath);
-    } catch (cleanupError) {
-      cleanupErrors.push(
-        `remove worktree: ${getErrorMessage(cleanupError)}`
-      );
-    }
-
-    if (!branchExistedBeforeCheckout) {
-      try {
-        if (await localBranchExists(context.repoRoot, branchName)) {
-          await deleteBranch(context.repoRoot, branchName);
-        }
-      } catch (cleanupError) {
-        cleanupErrors.push(
-          `delete branch ${branchName}: ${getErrorMessage(cleanupError)}`
-        );
-      }
-    }
-
-    if (cleanupErrors.length > 0) {
-      throw new AppError(
-        `${getErrorMessage(error)}\nCleanup failed for temporary PR worktree ${worktreePath}: ${cleanupErrors.join("; ")}`
-      );
-    }
-
-    throw error;
-  }
-
-  await copyConfiguredPaths(settings, context.repoRoot, worktreePath);
-
-  await writeWorktreeMeta(
-    worktreePath,
-    createWorktreeMeta(baseBranch, baseCommit, undefined, {
-      id,
-      fullId,
-      prNumber: pullRequestInfo.number,
-      prUrl: pullRequestInfo.url,
-    })
-  );
-
-  const postScriptResult = await runPostCreationScripts(
-    settings,
-    worktreePath,
-    scriptEnv
-  );
-
-  return {
-    branchName,
-    id,
-    fullId,
-    worktreePath,
-    baseBranch,
-    baseCommit,
-    idAdjustedFrom,
-    ...postScriptResult,
-  };
+  return createPreparedWorktree({
+    kind: "pull-request",
+    context,
+    pullRequest,
+    existingIds: worktrees.map((worktree) => worktree.id),
+  });
 }

--- a/src/app/use-cases/create-worktree.ts
+++ b/src/app/use-cases/create-worktree.ts
@@ -1,86 +1,13 @@
-import { existsSync } from "fs";
-import { join } from "path";
 import {
-  buildWorktreeIdentifiers,
-  buildWorktreePathCollisionSuffix,
-  buildWorktreePathName,
-  createWorktreeMeta,
-} from "../../domain/worktree.js";
-import {
-  createScriptEnvironment,
-  ensureWorktreeBaseDir,
-  runPostCreationScripts,
-  runPreCreationScripts,
+  createPreparedWorktree,
   type CreateWorktreeResult,
 } from "../worktree-creation.js";
-import { copyConfiguredPaths } from "../worktree-copy.js";
 import { requireRepositoryContext } from "../repository-context.js";
-import {
-  loadSettings,
-  resolveWorktreeDir,
-} from "../../infra/storage/settings-store.js";
-import {
-  createGitWorktree,
-  fetchRemote,
-} from "../../infra/git/worktree-repository.js";
-import { getCommitHash } from "../../infra/git/status.js";
-import {
-  readWorktreeMeta,
-  writeWorktreeMeta,
-} from "../../infra/storage/worktree-meta-store.js";
 
 export interface CreateWorktreeOptions {
   base?: string;
   push?: boolean;
   id?: string;
-}
-
-async function canReuseWorktreePath(
-  repoName: string,
-  worktreePath: string,
-  id: string
-): Promise<boolean> {
-  if (!existsSync(worktreePath)) {
-    return true;
-  }
-
-  const meta = await readWorktreeMeta(worktreePath);
-
-  if (!meta) {
-    return false;
-  }
-
-  return buildWorktreeIdentifiers(repoName, worktreePath, meta).id === id;
-}
-
-async function resolveWorktreePath(
-  worktreeBaseDir: string,
-  repoName: string,
-  id: string
-): Promise<string> {
-  const basePath = join(worktreeBaseDir, buildWorktreePathName(repoName, id));
-
-  if (await canReuseWorktreePath(repoName, basePath, id)) {
-    return basePath;
-  }
-
-  const collisionSuffix = buildWorktreePathCollisionSuffix(id);
-  let attempt = 0;
-
-  while (true) {
-    const suffix =
-      attempt === 0 ? collisionSuffix : `${collisionSuffix}-${attempt + 1}`;
-    const candidatePath = join(
-      worktreeBaseDir,
-      buildWorktreePathName(repoName, id, suffix)
-    );
-
-    if (await canReuseWorktreePath(repoName, candidatePath, id)) {
-      return candidatePath;
-    }
-
-    attempt += 1;
-  }
 }
 
 export async function createWorktree(
@@ -89,67 +16,11 @@ export async function createWorktree(
   cwd: string = process.cwd()
 ): Promise<CreateWorktreeResult> {
   const context = await requireRepositoryContext(cwd);
-  const settings = await loadSettings(context.repoRoot);
-  const baseBranch = options.base ?? settings.baseBranch;
-  const pushRemote = options.push ?? settings.pushRemote;
-  const id = options.id ?? branchName;
-  const fullId = `${context.repoName}-${id}`;
-  const worktreeBaseDir = resolveWorktreeDir(
-    settings.worktreeDir,
-    context.repoRoot
-  );
 
-  ensureWorktreeBaseDir(worktreeBaseDir);
-
-  const worktreePath = await resolveWorktreePath(
-    worktreeBaseDir,
-    context.repoName,
-    id
-  );
-
-  await fetchRemote(context.repoRoot);
-
-  const baseCommit = await getCommitHash(context.repoRoot, baseBranch);
-  const scriptEnv = createScriptEnvironment(
-    context.repoRoot,
-    worktreePath,
-    id,
-    fullId,
-    branchName
-  );
-
-  await runPreCreationScripts(settings, context.repoRoot, scriptEnv);
-
-  await createGitWorktree(
-    context.repoRoot,
-    worktreePath,
+  return createPreparedWorktree({
+    kind: "new",
+    context,
     branchName,
-    baseBranch,
-    pushRemote
-  );
-  await copyConfiguredPaths(settings, context.repoRoot, worktreePath);
-
-  await writeWorktreeMeta(
-    worktreePath,
-    createWorktreeMeta(baseBranch, baseCommit, undefined, {
-      id,
-      fullId,
-    })
-  );
-
-  const postScriptResult = await runPostCreationScripts(
-    settings,
-    worktreePath,
-    scriptEnv
-  );
-
-  return {
-    branchName,
-    id,
-    fullId,
-    worktreePath,
-    baseBranch,
-    baseCommit,
-    ...postScriptResult,
-  };
+    options,
+  });
 }

--- a/src/app/worktree-creation.test.ts
+++ b/src/app/worktree-creation.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_WT_SETTINGS } from "../domain/settings.js";
+import {
+  createWorktreeCreator,
+  type WorktreeCreationDependencies,
+} from "./worktree-creation.js";
+
+function createNoopDependencies(): WorktreeCreationDependencies {
+  return {
+    settings: {
+      load: async () => ({
+        ...DEFAULT_WT_SETTINGS,
+        worktreeDir: "/worktrees",
+        pushRemote: false,
+      }),
+      resolveWorktreeDir: (path) => path,
+    },
+    files: {
+      exists: () => false,
+      ensureDirectory: () => undefined,
+    },
+    metadata: {
+      read: async () => undefined,
+      write: async () => undefined,
+    },
+    git: {
+      fetchRemote: async () => undefined,
+      fetchRemoteBranch: async () => true,
+      getCommitHash: async () => "base-commit",
+      getMergeBase: async () => "merge-base",
+      resolveCommitHash: async () => ({
+        commitHash: "base-commit",
+        resolvedRef: "main",
+      }),
+      isRefAncestor: async () => true,
+      localBranchExists: async () => false,
+      createNew: async () => undefined,
+      attachExisting: async () => undefined,
+      createDetached: async () => undefined,
+      checkoutPullRequest: async () => undefined,
+      remove: async () => undefined,
+      deleteBranch: async () => undefined,
+    },
+    scripts: {
+      runPre: async () => undefined,
+      runPost: async () => ({}),
+    },
+    copy: async () => undefined,
+  };
+}
+
+const repositoryContext = {
+  cwd: "/repo",
+  repoRoot: "/repo",
+  repoName: "project",
+};
+
+function createLifecycleDependencies(): {
+  dependencies: WorktreeCreationDependencies;
+  getStage: () => number;
+  getWrittenMeta: () => unknown;
+} {
+  let stage = 0;
+  let writtenMeta: unknown;
+
+  return {
+    dependencies: {
+      settings: {
+        load: async () => ({
+          ...DEFAULT_WT_SETTINGS,
+          worktreeDir: "/worktrees",
+          pushRemote: false,
+          scripts: {
+            pre: ["prepare"],
+            post: ["finish"],
+            postMode: "sync",
+          },
+        }),
+        resolveWorktreeDir: (path) => path,
+      },
+      files: {
+        exists: () => false,
+        ensureDirectory: () => undefined,
+      },
+      metadata: {
+        read: async () => undefined,
+        write: async (_path, meta) => {
+          expect(stage).toBe(3);
+          writtenMeta = meta;
+          stage = 4;
+        },
+      },
+      git: {
+        fetchRemote: async () => undefined,
+        fetchRemoteBranch: async () => true,
+        getCommitHash: async () => "base-commit",
+        getMergeBase: async () => "base-commit",
+        resolveCommitHash: async () => ({
+          commitHash: "base-commit",
+          resolvedRef: "main",
+        }),
+        isRefAncestor: async () => true,
+        localBranchExists: async () => false,
+        createNew: async () => {
+          expect(stage).toBe(1);
+          stage = 2;
+        },
+        attachExisting: async () => undefined,
+        createDetached: async () => undefined,
+        checkoutPullRequest: async () => undefined,
+        remove: async () => undefined,
+        deleteBranch: async () => undefined,
+      },
+      scripts: {
+        runPre: async () => {
+          expect(stage).toBe(0);
+          stage = 1;
+        },
+        runPost: async () => {
+          expect(stage).toBe(4);
+          stage = 5;
+          return { postMode: "sync" };
+        },
+      },
+      copy: async () => {
+        expect(stage).toBe(2);
+        stage = 3;
+      },
+    },
+    getStage: () => stage,
+    getWrittenMeta: () => writtenMeta,
+  };
+}
+
+describe("worktree creation", () => {
+  test("creates a new worktree through one lifecycle", async () => {
+    const fixture = createLifecycleDependencies();
+    const create = createWorktreeCreator(fixture.dependencies);
+
+    const result = await create({
+      kind: "new",
+      context: repositoryContext,
+      branchName: "feature/a",
+      options: {
+        base: "main",
+        id: "feature/a",
+        push: false,
+      },
+    });
+
+    expect(result).toEqual({
+      branchName: "feature/a",
+      id: "feature/a",
+      fullId: "project-feature/a",
+      worktreePath: "/worktrees/project-feature-a",
+      baseBranch: "main",
+      baseCommit: "base-commit",
+      postMode: "sync",
+    });
+    expect(fixture.getWrittenMeta()).toMatchObject({
+      id: "feature/a",
+      fullId: "project-feature/a",
+      baseBranch: "main",
+      baseCommit: "base-commit",
+    });
+    expect(fixture.getStage()).toBe(5);
+  });
+
+  test("creates a worktree for an existing branch with an adjusted id", async () => {
+    const dependencies = createNoopDependencies();
+    dependencies.scripts.runPost = async () => ({
+      postMode: "async",
+      postTask: {
+        pid: 42,
+        statusFilePath: "/worktrees/task.json",
+        logFilePath: "/worktrees/task.log",
+      },
+    });
+    const create = createWorktreeCreator(dependencies);
+
+    const result = await create({
+      kind: "existing-branch",
+      context: repositoryContext,
+      branchName: "feature/a",
+      existingIds: ["feature/a"],
+    });
+
+    expect(result).toEqual({
+      branchName: "feature/a",
+      id: "feature/a-1",
+      fullId: "project-feature/a-1",
+      worktreePath: "/worktrees/project-feature-a-1",
+      baseBranch: "main",
+      baseCommit: "merge-base",
+      idAdjustedFrom: "feature/a",
+      postMode: "async",
+      postTask: {
+        pid: 42,
+        statusFilePath: "/worktrees/task.json",
+        logFilePath: "/worktrees/task.log",
+      },
+    });
+  });
+
+  test("rolls back a temporary pull request worktree when checkout fails", async () => {
+    const dependencies = createNoopDependencies();
+    const removedPaths: string[] = [];
+    const deletedBranches: string[] = [];
+    let branchLookupCount = 0;
+    dependencies.git.localBranchExists = async () => {
+      branchLookupCount += 1;
+      return branchLookupCount > 1;
+    };
+    dependencies.git.checkoutPullRequest = async () => {
+      throw new Error("checkout failed");
+    };
+    dependencies.git.remove = async (_repoRoot, worktreePath) => {
+      removedPaths.push(worktreePath);
+    };
+    dependencies.git.deleteBranch = async (_repoRoot, branch) => {
+      deletedBranches.push(branch);
+    };
+    const create = createWorktreeCreator(dependencies);
+
+    await expect(
+      create({
+        kind: "pull-request",
+        context: repositoryContext,
+        pullRequest: {
+          baseRefName: "main",
+          headRefName: "feature/pr",
+          headRefOid: "head-commit",
+          number: "17",
+          url: "https://example.test/pull/17",
+        },
+        existingIds: [],
+      })
+    ).rejects.toThrow("checkout failed");
+    expect(removedPaths).toEqual(["/worktrees/project-pr-17"]);
+    expect(deletedBranches).toEqual(["feature/pr"]);
+  });
+
+  test("does not materialize a worktree when a pre script fails", async () => {
+    const dependencies = createNoopDependencies();
+    let materialized = false;
+    dependencies.scripts.runPre = async () => {
+      throw new Error("pre failed");
+    };
+    dependencies.git.createNew = async () => {
+      materialized = true;
+    };
+    const create = createWorktreeCreator(dependencies);
+
+    await expect(
+      create({
+        kind: "new",
+        context: repositoryContext,
+        branchName: "feature/a",
+        options: {},
+      })
+    ).rejects.toThrow("pre failed");
+    expect(materialized).toBe(false);
+  });
+
+  test("keeps the created worktree when copying configured paths fails", async () => {
+    const dependencies = createNoopDependencies();
+    let materialized = false;
+    let metadataWritten = false;
+    let removed = false;
+    dependencies.git.createNew = async () => {
+      materialized = true;
+    };
+    dependencies.copy = async () => {
+      throw new Error("copy failed");
+    };
+    dependencies.metadata.write = async () => {
+      metadataWritten = true;
+    };
+    dependencies.git.remove = async () => {
+      removed = true;
+    };
+    const create = createWorktreeCreator(dependencies);
+
+    await expect(
+      create({
+        kind: "new",
+        context: repositoryContext,
+        branchName: "feature/a",
+        options: {},
+      })
+    ).rejects.toThrow("copy failed");
+    expect(materialized).toBe(true);
+    expect(metadataWritten).toBe(false);
+    expect(removed).toBe(false);
+  });
+});

--- a/src/app/worktree-creation.ts
+++ b/src/app/worktree-creation.ts
@@ -2,13 +2,47 @@ import { existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import type { WtSettings } from "../domain/settings.js";
 import {
+  buildWorktreeIdentifiers,
   buildWorktreePathCollisionSuffix,
   buildWorktreePathName,
+  createWorktreeMeta,
+  type WorktreeMeta,
 } from "../domain/worktree.js";
+import {
+  attachGitWorktree,
+  createDetachedGitWorktree,
+  createGitWorktree,
+  deleteBranch,
+  fetchRemote,
+  fetchRemoteBranch,
+  localBranchExists,
+  removeGitWorktree,
+} from "../infra/git/worktree-repository.js";
+import {
+  getCommitHash,
+  getMergeBase,
+  isRefAncestor,
+  resolveCommitHash,
+} from "../infra/git/status.js";
+import {
+  checkoutPullRequest,
+  type PullRequestInfo,
+} from "../infra/github/cli.js";
 import {
   executeScripts,
   executeScriptsDetached,
 } from "../infra/scripts/runner.js";
+import {
+  loadSettings,
+  resolveWorktreeDir,
+} from "../infra/storage/settings-store.js";
+import {
+  readWorktreeMeta,
+  writeWorktreeMeta,
+} from "../infra/storage/worktree-meta-store.js";
+import { AppError } from "./errors.js";
+import type { RepositoryContext } from "./repository-context.js";
+import { copyConfiguredPaths } from "./worktree-copy.js";
 
 export interface CreateWorktreeResult {
   branchName: string;
@@ -27,13 +61,133 @@ export interface CreateWorktreeResult {
   };
 }
 
-export function ensureWorktreeBaseDir(worktreeBaseDir: string): void {
-  if (!existsSync(worktreeBaseDir)) {
-    mkdirSync(worktreeBaseDir, { recursive: true });
-  }
+interface NewWorktreeCreation {
+  kind: "new";
+  context: RepositoryContext;
+  branchName: string;
+  options: {
+    base?: string;
+    push?: boolean;
+    id?: string;
+  };
 }
 
-export function createScriptEnvironment(
+interface ExistingBranchWorktreeCreation {
+  kind: "existing-branch";
+  context: RepositoryContext;
+  branchName: string;
+  existingIds: string[];
+}
+
+interface PullRequestWorktreeCreation {
+  kind: "pull-request";
+  context: RepositoryContext;
+  pullRequest: PullRequestInfo;
+  existingIds: string[];
+}
+
+export type WorktreeCreationRequest =
+  | NewWorktreeCreation
+  | ExistingBranchWorktreeCreation
+  | PullRequestWorktreeCreation;
+
+type PostCreationResult = Pick<
+  CreateWorktreeResult,
+  "postMode" | "postTask"
+>;
+
+export interface WorktreeCreationDependencies {
+  settings: {
+    load: (repoRoot: string) => Promise<WtSettings>;
+    resolveWorktreeDir: (path: string, repoRoot: string) => string;
+  };
+  files: {
+    exists: (path: string) => boolean;
+    ensureDirectory: (path: string) => void;
+  };
+  metadata: {
+    read: (worktreePath: string) => Promise<WorktreeMeta | undefined>;
+    write: (worktreePath: string, meta: WorktreeMeta) => Promise<void>;
+  };
+  git: {
+    fetchRemote: (repoRoot: string) => Promise<void>;
+    fetchRemoteBranch: (repoRoot: string, branch: string) => Promise<boolean>;
+    getCommitHash: (repoRoot: string, ref: string) => Promise<string>;
+    getMergeBase: (
+      repoRoot: string,
+      firstRef: string,
+      secondRef: string
+    ) => Promise<string>;
+    resolveCommitHash: (
+      repoRoot: string,
+      refs: string[]
+    ) => Promise<{ commitHash: string; resolvedRef: string } | undefined>;
+    isRefAncestor: (
+      repoRoot: string,
+      ancestorRef: string,
+      descendantRef: string
+    ) => Promise<boolean>;
+    localBranchExists: (repoRoot: string, branch: string) => Promise<boolean>;
+    createNew: (
+      repoRoot: string,
+      worktreePath: string,
+      branch: string,
+      baseBranch: string,
+      pushRemote: boolean
+    ) => Promise<void>;
+    attachExisting: (
+      repoRoot: string,
+      worktreePath: string,
+      branch: string
+    ) => Promise<void>;
+    createDetached: (
+      repoRoot: string,
+      worktreePath: string,
+      ref: string
+    ) => Promise<void>;
+    checkoutPullRequest: (
+      worktreePath: string,
+      pullRequestNumber: string
+    ) => Promise<void>;
+    remove: (repoRoot: string, worktreePath: string) => Promise<void>;
+    deleteBranch: (repoRoot: string, branch: string) => Promise<void>;
+  };
+  scripts: {
+    runPre: (
+      settings: WtSettings,
+      repoRoot: string,
+      environment: Record<string, string>
+    ) => Promise<void>;
+    runPost: (
+      settings: WtSettings,
+      worktreePath: string,
+      environment: Record<string, string>
+    ) => Promise<PostCreationResult>;
+  };
+  copy: (
+    settings: Pick<WtSettings, "copy">,
+    repoRoot: string,
+    worktreePath: string
+  ) => Promise<void>;
+}
+
+interface PreparedCreation {
+  branchName: string;
+  id: string;
+  fullId: string;
+  worktreePath: string;
+  baseBranch: string;
+  baseCommit: string;
+  idAdjustedFrom?: string;
+  metadata?: Pick<WorktreeMeta, "prNumber" | "prUrl">;
+  materialize: () => Promise<void>;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function createScriptEnvironment(
   repoRoot: string,
   worktreePath: string,
   id: string,
@@ -49,87 +203,7 @@ export function createScriptEnvironment(
   };
 }
 
-export async function runPreCreationScripts(
-  settings: WtSettings,
-  repoRoot: string,
-  scriptEnv: Record<string, string>
-): Promise<void> {
-  if (settings.scripts.pre.length === 0) {
-    return;
-  }
-
-  await executeScripts(settings.scripts.pre, repoRoot, scriptEnv);
-}
-
-export async function runPostCreationScripts(
-  settings: WtSettings,
-  worktreePath: string,
-  scriptEnv: Record<string, string>
-): Promise<Pick<CreateWorktreeResult, "postMode" | "postTask">> {
-  if (settings.scripts.post.length === 0) {
-    return {};
-  }
-
-  if (settings.scripts.postMode === "async") {
-    const wtDir = join(worktreePath, ".wt");
-    const statusFilePath = join(wtDir, "post-task.json");
-    const logFilePath = join(wtDir, "post-task.log");
-    const pid = executeScriptsDetached(
-      settings.scripts.post,
-      worktreePath,
-      scriptEnv,
-      statusFilePath,
-      logFilePath
-    );
-
-    return {
-      postMode: "async",
-      postTask: {
-        pid,
-        statusFilePath,
-        logFilePath,
-      },
-    };
-  }
-
-  await executeScripts(settings.scripts.post, worktreePath, scriptEnv);
-
-  return {
-    postMode: "sync",
-  };
-}
-
-export function resolveFreshWorktreePath(
-  worktreeBaseDir: string,
-  repoName: string,
-  id: string
-): string {
-  const basePath = join(worktreeBaseDir, buildWorktreePathName(repoName, id));
-
-  if (!existsSync(basePath)) {
-    return basePath;
-  }
-
-  const collisionSuffix = buildWorktreePathCollisionSuffix(id);
-  let attempt = 0;
-
-  while (true) {
-    const suffix =
-      attempt === 0 ? collisionSuffix : `${collisionSuffix}-${attempt + 1}`;
-    const candidatePath = join(
-      worktreeBaseDir,
-      buildWorktreePathName(repoName, id, suffix)
-    );
-
-    if (!existsSync(candidatePath)) {
-      return candidatePath;
-    }
-
-    attempt += 1;
-  }
-}
-
-export function resolveUniqueWorktreeId(
+function resolveUniqueWorktreeId(
   preferredId: string,
   existingIds: string[]
 ): Pick<CreateWorktreeResult, "id" | "idAdjustedFrom"> {
@@ -150,3 +224,480 @@ export function resolveUniqueWorktreeId(
     idAdjustedFrom: preferredId,
   };
 }
+
+function resolveFreshWorktreePath(
+  dependencies: WorktreeCreationDependencies,
+  worktreeBaseDir: string,
+  repoName: string,
+  id: string
+): string {
+  const basePath = join(worktreeBaseDir, buildWorktreePathName(repoName, id));
+
+  if (!dependencies.files.exists(basePath)) {
+    return basePath;
+  }
+
+  const collisionSuffix = buildWorktreePathCollisionSuffix(id);
+  let attempt = 0;
+
+  while (true) {
+    const suffix =
+      attempt === 0 ? collisionSuffix : `${collisionSuffix}-${attempt + 1}`;
+    const candidatePath = join(
+      worktreeBaseDir,
+      buildWorktreePathName(repoName, id, suffix)
+    );
+
+    if (!dependencies.files.exists(candidatePath)) {
+      return candidatePath;
+    }
+
+    attempt += 1;
+  }
+}
+
+async function canReuseWorktreePath(
+  dependencies: WorktreeCreationDependencies,
+  repoName: string,
+  worktreePath: string,
+  id: string
+): Promise<boolean> {
+  if (!dependencies.files.exists(worktreePath)) {
+    return true;
+  }
+
+  const meta = await dependencies.metadata.read(worktreePath);
+  return meta
+    ? buildWorktreeIdentifiers(repoName, worktreePath, meta).id === id
+    : false;
+}
+
+async function resolveReusableWorktreePath(
+  dependencies: WorktreeCreationDependencies,
+  worktreeBaseDir: string,
+  repoName: string,
+  id: string
+): Promise<string> {
+  const basePath = join(worktreeBaseDir, buildWorktreePathName(repoName, id));
+
+  if (await canReuseWorktreePath(dependencies, repoName, basePath, id)) {
+    return basePath;
+  }
+
+  const collisionSuffix = buildWorktreePathCollisionSuffix(id);
+  let attempt = 0;
+
+  while (true) {
+    const suffix =
+      attempt === 0 ? collisionSuffix : `${collisionSuffix}-${attempt + 1}`;
+    const candidatePath = join(
+      worktreeBaseDir,
+      buildWorktreePathName(repoName, id, suffix)
+    );
+
+    if (
+      await canReuseWorktreePath(
+        dependencies,
+        repoName,
+        candidatePath,
+        id
+      )
+    ) {
+      return candidatePath;
+    }
+
+    attempt += 1;
+  }
+}
+
+async function resolvePullRequestBaseCommit(
+  dependencies: WorktreeCreationDependencies,
+  repoRoot: string,
+  baseBranch: string
+): Promise<string> {
+  const initialResolution = await dependencies.git.resolveCommitHash(repoRoot, [
+    baseBranch,
+    `origin/${baseBranch}`,
+    `refs/remotes/origin/${baseBranch}`,
+  ]);
+
+  if (initialResolution) {
+    return initialResolution.commitHash;
+  }
+
+  await dependencies.git.fetchRemoteBranch(repoRoot, baseBranch);
+  const fetchedResolution = await dependencies.git.resolveCommitHash(repoRoot, [
+    `origin/${baseBranch}`,
+    `refs/remotes/origin/${baseBranch}`,
+    baseBranch,
+  ]);
+
+  if (fetchedResolution) {
+    return fetchedResolution.commitHash;
+  }
+
+  throw new AppError(
+    `Could not resolve PR base branch ${baseBranch} from origin. Fetch it manually or confirm the branch still exists.`
+  );
+}
+
+async function prepareNewCreation(
+  dependencies: WorktreeCreationDependencies,
+  request: NewWorktreeCreation,
+  settings: WtSettings,
+  worktreeBaseDir: string
+): Promise<PreparedCreation> {
+  const { context, branchName, options } = request;
+  const baseBranch = options.base ?? settings.baseBranch;
+  const pushRemote = options.push ?? settings.pushRemote;
+  const id = options.id ?? branchName;
+  const fullId = `${context.repoName}-${id}`;
+  const worktreePath = await resolveReusableWorktreePath(
+    dependencies,
+    worktreeBaseDir,
+    context.repoName,
+    id
+  );
+
+  await dependencies.git.fetchRemote(context.repoRoot);
+  const baseCommit = await dependencies.git.getCommitHash(
+    context.repoRoot,
+    baseBranch
+  );
+
+  return {
+    branchName,
+    id,
+    fullId,
+    worktreePath,
+    baseBranch,
+    baseCommit,
+    materialize: () =>
+      dependencies.git.createNew(
+        context.repoRoot,
+        worktreePath,
+        branchName,
+        baseBranch,
+        pushRemote
+      ),
+  };
+}
+
+async function prepareExistingBranchCreation(
+  dependencies: WorktreeCreationDependencies,
+  request: ExistingBranchWorktreeCreation,
+  settings: WtSettings,
+  worktreeBaseDir: string
+): Promise<PreparedCreation> {
+  const { context, branchName } = request;
+  const { id, idAdjustedFrom } = resolveUniqueWorktreeId(
+    branchName,
+    request.existingIds
+  );
+  const fullId = `${context.repoName}-${id}`;
+  const worktreePath = resolveFreshWorktreePath(
+    dependencies,
+    worktreeBaseDir,
+    context.repoName,
+    id
+  );
+  const baseBranch = settings.baseBranch;
+  const baseCommit =
+    (await dependencies.git.getMergeBase(
+      context.repoRoot,
+      branchName,
+      baseBranch
+    )) ||
+    (await dependencies.git.getCommitHash(context.repoRoot, baseBranch));
+
+  return {
+    branchName,
+    id,
+    fullId,
+    worktreePath,
+    baseBranch,
+    baseCommit,
+    idAdjustedFrom,
+    materialize: () =>
+      dependencies.git.attachExisting(
+        context.repoRoot,
+        worktreePath,
+        branchName
+      ),
+  };
+}
+
+async function preparePullRequestCreation(
+  dependencies: WorktreeCreationDependencies,
+  request: PullRequestWorktreeCreation,
+  worktreeBaseDir: string
+): Promise<PreparedCreation> {
+  const { context, pullRequest } = request;
+  const branchName = pullRequest.headRefName;
+  const preferredId = `pr-${pullRequest.number}`;
+  const { id, idAdjustedFrom } = resolveUniqueWorktreeId(
+    preferredId,
+    request.existingIds
+  );
+  const fullId = `${context.repoName}-${id}`;
+
+  await dependencies.git.fetchRemote(context.repoRoot);
+
+  const baseBranch = pullRequest.baseRefName;
+  const baseCommit = await resolvePullRequestBaseCommit(
+    dependencies,
+    context.repoRoot,
+    baseBranch
+  );
+  const branchExistedBeforeCheckout =
+    await dependencies.git.localBranchExists(context.repoRoot, branchName);
+
+  if (
+    branchExistedBeforeCheckout &&
+    !(await dependencies.git.isRefAncestor(
+      context.repoRoot,
+      branchName,
+      pullRequest.headRefOid
+    ))
+  ) {
+    throw new AppError(
+      `Local branch ${branchName} already exists but diverges from PR #${pullRequest.number}. Refusing to reset it automatically; delete or rename the local branch, or merge/rebase it manually first.`
+    );
+  }
+
+  const worktreePath = resolveFreshWorktreePath(
+    dependencies,
+    worktreeBaseDir,
+    context.repoName,
+    id
+  );
+
+  return {
+    branchName,
+    id,
+    fullId,
+    worktreePath,
+    baseBranch,
+    baseCommit,
+    idAdjustedFrom,
+    metadata: {
+      prNumber: pullRequest.number,
+      prUrl: pullRequest.url,
+    },
+    materialize: async () => {
+      await dependencies.git.createDetached(
+        context.repoRoot,
+        worktreePath,
+        baseCommit
+      );
+
+      try {
+        await dependencies.git.checkoutPullRequest(
+          worktreePath,
+          pullRequest.number
+        );
+      } catch (error) {
+        const cleanupErrors: string[] = [];
+
+        try {
+          await dependencies.git.remove(context.repoRoot, worktreePath);
+        } catch (cleanupError) {
+          cleanupErrors.push(
+            `remove worktree: ${getErrorMessage(cleanupError)}`
+          );
+        }
+
+        if (!branchExistedBeforeCheckout) {
+          try {
+            if (
+              await dependencies.git.localBranchExists(
+                context.repoRoot,
+                branchName
+              )
+            ) {
+              await dependencies.git.deleteBranch(
+                context.repoRoot,
+                branchName
+              );
+            }
+          } catch (cleanupError) {
+            cleanupErrors.push(
+              `delete branch ${branchName}: ${getErrorMessage(cleanupError)}`
+            );
+          }
+        }
+
+        if (cleanupErrors.length > 0) {
+          throw new AppError(
+            `${getErrorMessage(error)}\nCleanup failed for temporary PR worktree ${worktreePath}: ${cleanupErrors.join("; ")}`
+          );
+        }
+
+        throw error;
+      }
+    },
+  };
+}
+
+async function runPreCreationScripts(
+  settings: WtSettings,
+  repoRoot: string,
+  environment: Record<string, string>
+): Promise<void> {
+  if (settings.scripts.pre.length > 0) {
+    await executeScripts(settings.scripts.pre, repoRoot, environment);
+  }
+}
+
+async function runPostCreationScripts(
+  settings: WtSettings,
+  worktreePath: string,
+  environment: Record<string, string>
+): Promise<PostCreationResult> {
+  if (settings.scripts.post.length === 0) {
+    return {};
+  }
+
+  if (settings.scripts.postMode === "async") {
+    const wtDir = join(worktreePath, ".wt");
+    const statusFilePath = join(wtDir, "post-task.json");
+    const logFilePath = join(wtDir, "post-task.log");
+    const pid = executeScriptsDetached(
+      settings.scripts.post,
+      worktreePath,
+      environment,
+      statusFilePath,
+      logFilePath
+    );
+
+    return {
+      postMode: "async",
+      postTask: { pid, statusFilePath, logFilePath },
+    };
+  }
+
+  await executeScripts(settings.scripts.post, worktreePath, environment);
+  return { postMode: "sync" };
+}
+
+const defaultDependencies: WorktreeCreationDependencies = {
+  settings: {
+    load: loadSettings,
+    resolveWorktreeDir,
+  },
+  files: {
+    exists: existsSync,
+    ensureDirectory: (path) => {
+      if (!existsSync(path)) {
+        mkdirSync(path, { recursive: true });
+      }
+    },
+  },
+  metadata: {
+    read: readWorktreeMeta,
+    write: writeWorktreeMeta,
+  },
+  git: {
+    fetchRemote,
+    fetchRemoteBranch,
+    getCommitHash,
+    getMergeBase,
+    resolveCommitHash,
+    isRefAncestor,
+    localBranchExists,
+    createNew: createGitWorktree,
+    attachExisting: attachGitWorktree,
+    createDetached: createDetachedGitWorktree,
+    checkoutPullRequest,
+    remove: removeGitWorktree,
+    deleteBranch,
+  },
+  scripts: {
+    runPre: runPreCreationScripts,
+    runPost: runPostCreationScripts,
+  },
+  copy: copyConfiguredPaths,
+};
+
+export function createWorktreeCreator(
+  dependencies: WorktreeCreationDependencies
+): (request: WorktreeCreationRequest) => Promise<CreateWorktreeResult> {
+  return async (request) => {
+    const { context } = request;
+    const settings = await dependencies.settings.load(context.repoRoot);
+    const worktreeBaseDir = dependencies.settings.resolveWorktreeDir(
+      settings.worktreeDir,
+      context.repoRoot
+    );
+    dependencies.files.ensureDirectory(worktreeBaseDir);
+
+    const prepared =
+      request.kind === "new"
+        ? await prepareNewCreation(
+            dependencies,
+            request,
+            settings,
+            worktreeBaseDir
+          )
+        : request.kind === "existing-branch"
+          ? await prepareExistingBranchCreation(
+              dependencies,
+              request,
+              settings,
+              worktreeBaseDir
+            )
+          : await preparePullRequestCreation(
+              dependencies,
+              request,
+              worktreeBaseDir
+            );
+    const environment = createScriptEnvironment(
+      context.repoRoot,
+      prepared.worktreePath,
+      prepared.id,
+      prepared.fullId,
+      prepared.branchName
+    );
+
+    await dependencies.scripts.runPre(
+      settings,
+      context.repoRoot,
+      environment
+    );
+    await prepared.materialize();
+    await dependencies.copy(
+      settings,
+      context.repoRoot,
+      prepared.worktreePath
+    );
+    await dependencies.metadata.write(
+      prepared.worktreePath,
+      createWorktreeMeta(prepared.baseBranch, prepared.baseCommit, undefined, {
+        id: prepared.id,
+        fullId: prepared.fullId,
+        ...prepared.metadata,
+      })
+    );
+    const postResult = await dependencies.scripts.runPost(
+      settings,
+      prepared.worktreePath,
+      environment
+    );
+
+    return {
+      branchName: prepared.branchName,
+      id: prepared.id,
+      fullId: prepared.fullId,
+      worktreePath: prepared.worktreePath,
+      baseBranch: prepared.baseBranch,
+      baseCommit: prepared.baseCommit,
+      ...(prepared.idAdjustedFrom
+        ? { idAdjustedFrom: prepared.idAdjustedFrom }
+        : {}),
+      ...postResult,
+    };
+  };
+}
+
+export const createPreparedWorktree =
+  createWorktreeCreator(defaultDependencies);


### PR DESCRIPTION
## Summary
- keep new, checkout, and PR creation as distinct user-facing use cases
- centralize settings, path and ID resolution, scripts, Git materialization, copying, metadata, and rollback in the worktree creation module
- add lifecycle tests for all creation modes and failure behavior

## Verification
- bun run typecheck
- bun test (221 pass, 0 fail)