### PR TITLE
refactor: deepen worktree removal lifecycle

### DIFF
--- a/src/app/use-cases/remove-worktree.test.ts
+++ b/src/app/use-cases/remove-worktree.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_WT_SETTINGS } from "../../domain/settings.js";
+import type { WorktreeInfo } from "../../domain/worktree.js";
+import {
+  createWorktreeRemoval,
+  type WorktreeRemovalDependencies,
+} from "./remove-worktree.js";
+
+const context = {
+  cwd: "/repo",
+  repoRoot: "/repo",
+  repoName: "project",
+};
+
+function createWorktree(): WorktreeInfo {
+  return {
+    id: "feature-a",
+    fullId: "project-feature-a",
+    path: "/worktrees/feature-a",
+    branch: "feature/a",
+    isMain: false,
+    repoName: "project",
+    createdAt: "2026-07-18T00:00:00.000Z",
+    baseBranch: "main",
+    baseCommit: "base-commit",
+  };
+}
+
+function createDependencies(): {
+  dependencies: WorktreeRemovalDependencies;
+  status: {
+    localCommitCount: number;
+    localChangeCount: number;
+    hasUnknownLocalCommits: boolean;
+  };
+  removedPaths: string[];
+  deletedBranches: string[];
+  changedDirectories: string[];
+  startedTasks: unknown[];
+} {
+  const worktree = createWorktree();
+  const status = {
+    localCommitCount: 0,
+    localChangeCount: 0,
+    hasUnknownLocalCommits: false,
+  };
+  const removedPaths: string[] = [];
+  const deletedBranches: string[] = [];
+  const changedDirectories: string[] = [];
+  const startedTasks: unknown[] = [];
+
+  return {
+    dependencies: {
+      repository: {
+        requireContext: async () => context,
+        loadWorktrees: async () => [worktree],
+        listPaths: async () => [
+          { path: "/repo", isMain: true },
+          { path: worktree.path, isMain: false },
+        ],
+        inspectStatus: async () => ({ ...status }),
+        inspectStatusEntries: async () => ({ entries: [], totalCount: 0 }),
+      },
+      settings: {
+        load: async () => DEFAULT_WT_SETTINGS,
+        ensureTaskArtifactsIgnored: async () => undefined,
+      },
+      git: {
+        remove: async (_repoRoot, worktreePath) => {
+          removedPaths.push(worktreePath);
+        },
+        deleteBranch: async (_repoRoot, branch) => {
+          deletedBranches.push(branch);
+        },
+      },
+      tasks: {
+        start: (options) => {
+          startedTasks.push(options);
+          return 42;
+        },
+      },
+      herdr: {
+        find: async () => ({ attempted: false }),
+        close: async () => ({ attempted: false, closed: false }),
+      },
+      runtime: {
+        changeDirectory: (path) => {
+          changedDirectories.push(path);
+        },
+        now: () => new Date("2026-07-18T00:00:00.000Z"),
+        platform: "linux",
+      },
+    },
+    status,
+    removedPaths,
+    deletedBranches,
+    changedDirectories,
+    startedTasks,
+  };
+}
+
+describe("worktree removal", () => {
+  test("does not remove a worktree when its approved plan becomes stale", async () => {
+    const fixture = createDependencies();
+    const removal = createWorktreeRemoval(fixture.dependencies);
+    const plan = await removal.inspect("feature-a", context.cwd);
+
+    fixture.status.localChangeCount = 1;
+
+    const result = await removal.execute(plan, {
+      execution: "foreground",
+    });
+
+    expect(result.status).toBe("plan_stale");
+    if (result.status !== "plan_stale") {
+      throw new Error("Expected a stale removal plan");
+    }
+    expect(result.latestPlan?.localChangeCount).toBe(1);
+    expect(fixture.removedPaths).toEqual([]);
+  });
+
+  test("removes a foreground worktree and its branch", async () => {
+    const fixture = createDependencies();
+    const removal = createWorktreeRemoval(fixture.dependencies);
+    const plan = await removal.inspect("feature-a", context.cwd);
+
+    const result = await removal.execute(plan, {
+      execution: "foreground",
+    });
+
+    expect(result).toMatchObject({
+      status: "removed",
+      branchDeleted: true,
+      warnings: [],
+    });
+    expect(fixture.removedPaths).toEqual(["/worktrees/feature-a"]);
+    expect(fixture.deletedBranches).toEqual(["feature/a"]);
+  });
+
+  test("starts background removal for the current non-main worktree", async () => {
+    const fixture = createDependencies();
+    fixture.dependencies.repository.requireContext = async () => ({
+      ...context,
+      cwd: "/worktrees/feature-a/nested",
+    });
+    const removal = createWorktreeRemoval(fixture.dependencies);
+    const plan = await removal.inspect(
+      "feature-a",
+      "/worktrees/feature-a/nested"
+    );
+
+    const result = await removal.execute(plan, { execution: "auto" });
+
+    expect(result).toMatchObject({
+      status: "background_started",
+      branchDeleteQueued: true,
+      relocatedToPath: "/repo",
+      pid: 42,
+    });
+    expect(fixture.startedTasks).toHaveLength(1);
+    expect(fixture.removedPaths).toEqual([]);
+    expect(fixture.changedDirectories).toEqual([]);
+  });
+
+  test("relocates the removal process before foreground removal of the current worktree", async () => {
+    const fixture = createDependencies();
+    fixture.dependencies.repository.requireContext = async () => ({
+      ...context,
+      cwd: "/worktrees/feature-a/nested",
+    });
+    const removal = createWorktreeRemoval(fixture.dependencies);
+    const plan = await removal.inspect(
+      "feature-a",
+      "/worktrees/feature-a/nested"
+    );
+
+    const result = await removal.execute(plan, {
+      execution: "foreground",
+    });
+
+    expect(result).toMatchObject({
+      status: "removed",
+      relocatedToPath: "/repo",
+    });
+    expect(fixture.changedDirectories).toEqual(["/repo"]);
+    expect(fixture.removedPaths).toEqual(["/worktrees/feature-a"]);
+  });
+
+  test("returns partial failure and Herdr warnings after removing the worktree", async () => {
+    const fixture = createDependencies();
+    fixture.dependencies.git.deleteBranch = async () => {
+      throw new Error("branch is checked out elsewhere");
+    };
+    fixture.dependencies.herdr.find = async () => ({
+      attempted: true,
+      workspaceId: "workspace-1",
+    });
+    fixture.dependencies.herdr.close = async () => ({
+      attempted: true,
+      closed: false,
+      error: "Herdr unavailable",
+    });
+    const removal = createWorktreeRemoval(fixture.dependencies);
+    const plan = await removal.inspect("feature-a", context.cwd);
+
+    const result = await removal.execute(plan, {
+      execution: "foreground",
+    });
+
+    expect(result).toEqual({
+      status: "worktree_removed_branch_failed",
+      worktree: createWorktree(),
+      relocatedToPath: undefined,
+      error: "branch is checked out elsewhere",
+      warnings: [
+        {
+          kind: "herdr_close_failed",
+          message: "Could not close Herdr workspace: Herdr unavailable",
+        },
+      ],
+    });
+    expect(fixture.removedPaths).toEqual(["/worktrees/feature-a"]);
+  });
+});

--- a/src/app/use-cases/remove-worktree.test.ts
+++ b/src/app/use-cases/remove-worktree.test.ts
@@ -37,6 +37,7 @@ function createDependencies(): {
   deletedBranches: string[];
   changedDirectories: string[];
   startedTasks: unknown[];
+  statusEntryInspectionLimits: Array<number | undefined>;
 } {
   const worktree = createWorktree();
   const status = {
@@ -48,6 +49,7 @@ function createDependencies(): {
   const deletedBranches: string[] = [];
   const changedDirectories: string[] = [];
   const startedTasks: unknown[] = [];
+  const statusEntryInspectionLimits: Array<number | undefined> = [];
 
   return {
     dependencies: {
@@ -59,7 +61,10 @@ function createDependencies(): {
           { path: worktree.path, isMain: false },
         ],
         inspectStatus: async () => ({ ...status }),
-        inspectStatusEntries: async () => ({ entries: [], totalCount: 0 }),
+        inspectStatusEntries: async (_worktreePath, limit) => {
+          statusEntryInspectionLimits.push(limit);
+          return { entries: [], totalCount: 0 };
+        },
       },
       settings: {
         load: async () => DEFAULT_WT_SETTINGS,
@@ -96,10 +101,31 @@ function createDependencies(): {
     deletedBranches,
     changedDirectories,
     startedTasks,
+    statusEntryInspectionLimits,
   };
 }
 
 describe("worktree removal", () => {
+  test("does not inspect status entries when removal details are not requested", async () => {
+    const fixture = createDependencies();
+    const removal = createWorktreeRemoval(fixture.dependencies);
+
+    await removal.inspect("feature-a", context.cwd);
+
+    expect(fixture.statusEntryInspectionLimits).toEqual([]);
+  });
+
+  test("bounds status entry inspection when removal details are requested", async () => {
+    const fixture = createDependencies();
+    const removal = createWorktreeRemoval(fixture.dependencies);
+
+    await removal.inspect("feature-a", context.cwd, {
+      includeStatusEntries: true,
+    });
+
+    expect(fixture.statusEntryInspectionLimits).toEqual([8]);
+  });
+
   test("does not remove a worktree when its approved plan becomes stale", async () => {
     const fixture = createDependencies();
     const removal = createWorktreeRemoval(fixture.dependencies);

--- a/src/app/use-cases/remove-worktree.ts
+++ b/src/app/use-cases/remove-worktree.ts
@@ -416,24 +416,23 @@ export function createWorktreeRemoval(
       target,
       cwd
     );
-    const [status, allStatusEntries, removalRoot] = await Promise.all([
+    const statusEntryLimit = options.statusEntryLimit ?? 8;
+    const [status, statusEntries, removalRoot] = await Promise.all([
       dependencies.repository.inspectStatus(
         context.repoRoot,
         worktree.path,
         worktree.branch,
         worktree.baseBranch
       ),
-      dependencies.repository.inspectStatusEntries(
-        worktree.path,
-        Number.MAX_SAFE_INTEGER
-      ),
+      options.includeStatusEntries
+        ? dependencies.repository.inspectStatusEntries(
+            worktree.path,
+            statusEntryLimit
+          )
+        : undefined,
       findSafeRemovalRoot(dependencies, context, worktree),
     ]);
     const isCurrent = isPathInside(worktree.path, context.cwd);
-    const statusEntryLimit = options.statusEntryLimit ?? 8;
-    const displayedStatusEntries = options.includeStatusEntries
-      ? allStatusEntries.entries.slice(0, statusEntryLimit)
-      : undefined;
 
     return {
       target: worktree.path,
@@ -441,11 +440,11 @@ export function createWorktreeRemoval(
       worktree,
       isCurrent,
       ...status,
-      ...(displayedStatusEntries
+      ...(statusEntries
         ? {
-            statusEntries: displayedStatusEntries,
+            statusEntries: statusEntries.entries,
             remainingStatusEntryCount: Math.max(
-              allStatusEntries.totalCount - displayedStatusEntries.length,
+              statusEntries.totalCount - statusEntries.entries.length,
               0
             ),
           }
@@ -455,7 +454,7 @@ export function createWorktreeRemoval(
         worktree,
         isCurrent,
         status,
-        statusEntries: allStatusEntries.entries,
+        statusEntries: statusEntries?.entries ?? [],
         removalRoot,
       }),
     };

--- a/src/app/use-cases/remove-worktree.ts
+++ b/src/app/use-cases/remove-worktree.ts
@@ -3,7 +3,10 @@ import { AppError } from "../errors.js";
 import { isPathInside } from "../../domain/path.js";
 import { resolveWorktreeTarget } from "../../domain/worktree-target.js";
 import { requireRepositoryContext } from "../repository-context.js";
+import type { RepositoryContext } from "../repository-context.js";
 import { loadWorktreeInfos } from "../worktree-catalog.js";
+import type { WtSettings } from "../../domain/settings.js";
+import type { WorktreeInfo } from "../../domain/worktree.js";
 import {
   deleteBranch,
   listGitWorktreePaths,
@@ -12,27 +15,33 @@ import {
 import {
   getWorktreeRemovalStatusSummary,
   getWorktreeStatusEntries,
+  type WorktreeRemovalStatusSummary,
+  type WorktreeStatusEntriesResult,
 } from "../../infra/git/status.js";
 import {
   executeDetachedTask,
   shellEscapeSingle,
+  type DetachedTaskOptions,
 } from "../../infra/scripts/runner.js";
 import {
   ensureRemoveTaskArtifactsIgnored,
   loadSettings,
 } from "../../infra/storage/settings-store.js";
-import type { WorktreeInfo } from "../../domain/worktree.js";
 import {
   closeHerdrWorkspace,
   findHerdrWorkspaceForWorktree,
   type CloseHerdrWorkspaceResult,
+  type FindHerdrWorkspaceResult,
 } from "../../infra/herdr/client.js";
 
-export interface RemoveWorktreeOptions {
-  keepBranch?: boolean;
+export interface InspectRemovalOptions {
+  includeStatusEntries?: boolean;
+  statusEntryLimit?: number;
 }
 
-export interface RemoveWorktreePreview {
+export interface RemovalPlan {
+  target: string;
+  context: RepositoryContext;
   worktree: WorktreeInfo;
   isCurrent: boolean;
   localCommitCount: number;
@@ -40,54 +49,109 @@ export interface RemoveWorktreePreview {
   hasUnknownLocalCommits: boolean;
   statusEntries?: string[];
   remainingStatusEntryCount?: number;
+  removalRoot: {
+    gitRoot: string;
+    relocatedToPath?: string;
+  };
+  revision: string;
 }
 
-export interface InspectRemoveWorktreeOptions {
-  includeStatusEntries?: boolean;
-  statusEntryLimit?: number;
+export interface ExecuteRemovalOptions {
+  keepBranch?: boolean;
+  execution: "auto" | "foreground";
 }
 
-export interface RemoveWorktreeResult {
+export interface RemovalWarning {
+  kind: "herdr_find_failed" | "herdr_close_failed";
+  message: string;
+}
+
+export interface RemovedWorktreeResult {
+  status: "removed";
   worktree: WorktreeInfo;
   branchDeleted: boolean;
   relocatedToPath?: string;
-  herdrWorkspaceId?: string;
-  herdrError?: string;
+  warnings: RemovalWarning[];
 }
 
-export interface BackgroundRemoveWorktreeResult {
+export interface BackgroundRemovalResult {
+  status: "background_started";
   worktree: WorktreeInfo;
   branchDeleteQueued: boolean;
   relocatedToPath: string;
   pid: number;
   statusFilePath: string;
   logFilePath: string;
-  herdrWorkspaceId?: string;
-  herdrError?: string;
+  warnings: RemovalWarning[];
 }
 
-export async function closeRemovedWorktreeInHerdr(
-  workspaceId: string | undefined
-): Promise<CloseHerdrWorkspaceResult> {
-  return closeHerdrWorkspace(workspaceId);
+export interface BranchRemovalFailedResult {
+  status: "worktree_removed_branch_failed";
+  worktree: WorktreeInfo;
+  relocatedToPath?: string;
+  error: string;
+  warnings: RemovalWarning[];
 }
 
-export class RemoveWorktreeError extends AppError {
-  readonly relocatedToPath?: string;
+export interface StaleRemovalPlanResult {
+  status: "plan_stale";
+  latestPlan?: RemovalPlan;
+  reason: string;
+}
 
-  constructor(message: string, relocatedToPath?: string) {
-    super(message);
-    this.name = "RemoveWorktreeError";
-    this.relocatedToPath = relocatedToPath;
-  }
+export type RemovalResult =
+  | RemovedWorktreeResult
+  | BackgroundRemovalResult
+  | BranchRemovalFailedResult
+  | StaleRemovalPlanResult;
+
+export interface WorktreeRemovalDependencies {
+  repository: {
+    requireContext: (cwd: string) => Promise<RepositoryContext>;
+    loadWorktrees: (context: RepositoryContext) => Promise<WorktreeInfo[]>;
+    listPaths: (
+      repoRoot: string
+    ) => Promise<Array<{ path: string; isMain: boolean }>>;
+    inspectStatus: (
+      repoRoot: string,
+      worktreePath: string,
+      branch?: string,
+      baseBranch?: string
+    ) => Promise<WorktreeRemovalStatusSummary>;
+    inspectStatusEntries: (
+      worktreePath: string,
+      limit?: number
+    ) => Promise<WorktreeStatusEntriesResult>;
+  };
+  settings: {
+    load: (repoRoot: string) => Promise<WtSettings>;
+    ensureTaskArtifactsIgnored: (repoRoot: string) => Promise<void>;
+  };
+  git: {
+    remove: (repoRoot: string, worktreePath: string) => Promise<void>;
+    deleteBranch: (repoRoot: string, branch: string) => Promise<void>;
+  };
+  tasks: {
+    start: (options: DetachedTaskOptions) => number;
+  };
+  herdr: {
+    find: (worktreePath: string) => Promise<FindHerdrWorkspaceResult>;
+    close: (workspaceId: string | undefined) => Promise<CloseHerdrWorkspaceResult>;
+  };
+  runtime: {
+    changeDirectory: (path: string) => void;
+    now: () => Date;
+    platform: NodeJS.Platform;
+  };
+}
+
+interface HerdrRemovalContext {
+  workspaceId?: string;
+  warnings: RemovalWarning[];
 }
 
 function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return String(error);
+  return error instanceof Error ? error.message : String(error);
 }
 
 function findCurrentWorktree(
@@ -100,14 +164,12 @@ function findCurrentWorktree(
 }
 
 async function resolveRemovalTarget(
+  dependencies: WorktreeRemovalDependencies,
   target: string,
   cwd: string
-): Promise<{
-  context: Awaited<ReturnType<typeof requireRepositoryContext>>;
-  worktree: WorktreeInfo;
-}> {
-  const context = await requireRepositoryContext(cwd);
-  const worktrees = await loadWorktreeInfos(context);
+): Promise<{ context: RepositoryContext; worktree: WorktreeInfo }> {
+  const context = await dependencies.repository.requireContext(cwd);
+  const worktrees = await dependencies.repository.loadWorktrees(context);
 
   if (target === ".") {
     const currentWorktree = findCurrentWorktree(worktrees, context.cwd);
@@ -116,10 +178,7 @@ async function resolveRemovalTarget(
       throw new AppError("Current directory is not inside a git worktree");
     }
 
-    return {
-      context,
-      worktree: currentWorktree,
-    };
+    return { context, worktree: currentWorktree };
   }
 
   const result = resolveWorktreeTarget(worktrees, target, {
@@ -133,31 +192,23 @@ async function resolveRemovalTarget(
     );
   }
 
-  return {
-    context,
-    worktree: result.worktree,
-  };
+  return { context, worktree: result.worktree };
 }
 
 async function findSafeRemovalRoot(
-  context: Awaited<ReturnType<typeof requireRepositoryContext>>,
+  dependencies: WorktreeRemovalDependencies,
+  context: RepositoryContext,
   worktree: WorktreeInfo
-): Promise<{
-  gitRoot: string;
-  relocatedToPath?: string;
-}> {
+): Promise<RemovalPlan["removalRoot"]> {
   if (!isPathInside(worktree.path, context.cwd)) {
-    return {
-      gitRoot: context.repoRoot,
-    };
+    return { gitRoot: context.repoRoot };
   }
 
-  const worktrees = await listGitWorktreePaths(context.repoRoot);
+  const worktrees = await dependencies.repository.listPaths(context.repoRoot);
   const safeWorktree =
     worktrees.find(
       (candidate) => candidate.isMain && candidate.path !== worktree.path
-    ) ??
-    worktrees.find((candidate) => candidate.path !== worktree.path);
+    ) ?? worktrees.find((candidate) => candidate.path !== worktree.path);
 
   if (!safeWorktree) {
     throw new AppError(
@@ -171,20 +222,29 @@ async function findSafeRemovalRoot(
   };
 }
 
-async function resolveSafeRemovalRoot(
-  context: Awaited<ReturnType<typeof requireRepositoryContext>>,
-  worktree: WorktreeInfo
-): Promise<{
-  gitRoot: string;
-  relocatedToPath?: string;
-}> {
-  const removalRoot = await findSafeRemovalRoot(context, worktree);
-
-  if (removalRoot.relocatedToPath) {
-    process.chdir(removalRoot.relocatedToPath);
-  }
-
-  return removalRoot;
+function buildPlanRevision(input: {
+  worktree: WorktreeInfo;
+  isCurrent: boolean;
+  status: WorktreeRemovalStatusSummary;
+  statusEntries: string[];
+  removalRoot: RemovalPlan["removalRoot"];
+}): string {
+  return JSON.stringify({
+    id: input.worktree.id,
+    fullId: input.worktree.fullId,
+    path: input.worktree.path,
+    branch: input.worktree.branch,
+    head: input.worktree.head,
+    isMain: input.worktree.isMain,
+    baseBranch: input.worktree.baseBranch,
+    baseCommit: input.worktree.baseCommit,
+    isCurrent: input.isCurrent,
+    localCommitCount: input.status.localCommitCount,
+    localChangeCount: input.status.localChangeCount,
+    hasUnknownLocalCommits: input.status.hasUnknownLocalCommits,
+    statusEntries: input.statusEntries,
+    removalRoot: input.removalRoot,
+  });
 }
 
 function normalizeTaskPathSegment(value: string): string {
@@ -195,13 +255,14 @@ function normalizeTaskPathSegment(value: string): string {
 }
 
 function buildRemovalTaskPaths(
+  dependencies: WorktreeRemovalDependencies,
   safeWorktreePath: string,
   worktree: WorktreeInfo
-): {
-  statusFilePath: string;
-  logFilePath: string;
-} {
-  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+): { statusFilePath: string; logFilePath: string } {
+  const timestamp = dependencies.runtime
+    .now()
+    .toISOString()
+    .replace(/[:.]/g, "-");
   const taskName = `remove-task-${normalizeTaskPathSegment(worktree.id)}-${timestamp}`;
   const wtDir = join(safeWorktreePath, ".wt");
 
@@ -214,7 +275,7 @@ function buildRemovalTaskPaths(
 function buildRemovalTaskScripts(
   removalRoot: string,
   worktree: WorktreeInfo,
-  options: RemoveWorktreeOptions
+  options: ExecuteRemovalOptions
 ): string[] {
   const scripts = [
     `printf '%s\n' 'Removing worktree ${shellEscapeSingle(worktree.path)}'`,
@@ -255,169 +316,318 @@ function buildRemovalCompletionNotification(worktree: WorktreeInfo) {
   };
 }
 
-export async function inspectRemoveWorktree(
-  target: string,
-  cwd: string = process.cwd(),
-  options: InspectRemoveWorktreeOptions = {}
-): Promise<RemoveWorktreePreview> {
-  const { context, worktree } = await resolveRemovalTarget(target, cwd);
-  const {
-    localCommitCount,
-    localChangeCount,
-    hasUnknownLocalCommits,
-  } = await getWorktreeRemovalStatusSummary(
-    context.repoRoot,
-    worktree.path,
-    worktree.branch,
-    worktree.baseBranch
-  );
-  const statusEntriesResult = options.includeStatusEntries
-    ? await getWorktreeStatusEntries(
+async function inspectHerdrForRemoval(
+  dependencies: WorktreeRemovalDependencies,
+  settings: WtSettings,
+  worktreePath: string
+): Promise<HerdrRemovalContext> {
+  if (!settings.herdr.closeWorkspaceOnRemove) {
+    return { warnings: [] };
+  }
+
+  const result = await dependencies.herdr.find(worktreePath);
+
+  if (result.error) {
+    return {
+      warnings: [
+        {
+          kind: "herdr_find_failed",
+          message: `Could not find Herdr workspace: ${result.error}`,
+        },
+      ],
+    };
+  }
+
+  return { workspaceId: result.workspaceId, warnings: [] };
+}
+
+async function closeHerdrAfterRemoval(
+  dependencies: WorktreeRemovalDependencies,
+  context: HerdrRemovalContext
+): Promise<RemovalWarning[]> {
+  if (context.warnings.length > 0) {
+    return context.warnings;
+  }
+
+  const result = await dependencies.herdr.close(context.workspaceId);
+
+  return result.error
+    ? [
+        {
+          kind: "herdr_close_failed" as const,
+          message: `Could not close Herdr workspace: ${result.error}`,
+        },
+      ]
+    : [];
+}
+
+const defaultDependencies: WorktreeRemovalDependencies = {
+  repository: {
+    requireContext: requireRepositoryContext,
+    loadWorktrees: loadWorktreeInfos,
+    listPaths: listGitWorktreePaths,
+    inspectStatus: getWorktreeRemovalStatusSummary,
+    inspectStatusEntries: getWorktreeStatusEntries,
+  },
+  settings: {
+    load: loadSettings,
+    ensureTaskArtifactsIgnored: async (repoRoot) => {
+      await ensureRemoveTaskArtifactsIgnored(repoRoot);
+    },
+  },
+  git: {
+    remove: removeGitWorktree,
+    deleteBranch,
+  },
+  tasks: {
+    start: executeDetachedTask,
+  },
+  herdr: {
+    find: findHerdrWorkspaceForWorktree,
+    close: closeHerdrWorkspace,
+  },
+  runtime: {
+    changeDirectory: (path) => process.chdir(path),
+    now: () => new Date(),
+    platform: process.platform,
+  },
+};
+
+export function createWorktreeRemoval(
+  dependencies: WorktreeRemovalDependencies
+): {
+  inspect: (
+    target: string,
+    cwd?: string,
+    options?: InspectRemovalOptions
+  ) => Promise<RemovalPlan>;
+  execute: (
+    plan: RemovalPlan,
+    options: ExecuteRemovalOptions
+  ) => Promise<RemovalResult>;
+} {
+  const inspect = async (
+    target: string,
+    cwd: string = process.cwd(),
+    options: InspectRemovalOptions = {}
+  ): Promise<RemovalPlan> => {
+    const { context, worktree } = await resolveRemovalTarget(
+      dependencies,
+      target,
+      cwd
+    );
+    const [status, allStatusEntries, removalRoot] = await Promise.all([
+      dependencies.repository.inspectStatus(
+        context.repoRoot,
         worktree.path,
-        options.statusEntryLimit ?? 8
-      )
-    : undefined;
+        worktree.branch,
+        worktree.baseBranch
+      ),
+      dependencies.repository.inspectStatusEntries(
+        worktree.path,
+        Number.MAX_SAFE_INTEGER
+      ),
+      findSafeRemovalRoot(dependencies, context, worktree),
+    ]);
+    const isCurrent = isPathInside(worktree.path, context.cwd);
+    const statusEntryLimit = options.statusEntryLimit ?? 8;
+    const displayedStatusEntries = options.includeStatusEntries
+      ? allStatusEntries.entries.slice(0, statusEntryLimit)
+      : undefined;
 
-  return {
-    worktree,
-    isCurrent: isPathInside(worktree.path, context.cwd),
-    localCommitCount,
-    localChangeCount,
-    hasUnknownLocalCommits,
-    ...(statusEntriesResult
-      ? {
-          statusEntries: statusEntriesResult.entries,
-          remainingStatusEntryCount: Math.max(
-            statusEntriesResult.totalCount - statusEntriesResult.entries.length,
-            0
-          ),
-        }
-      : {}),
-  };
-}
-
-export async function removeWorktree(
-  target: string,
-  options: RemoveWorktreeOptions,
-  cwd: string = process.cwd()
-): Promise<RemoveWorktreeResult> {
-  const { context, worktree } = await resolveRemovalTarget(target, cwd);
-  const settings = await loadSettings(context.repoRoot);
-  const herdr = settings.herdr.closeWorkspaceOnRemove
-    ? await findHerdrWorkspaceForWorktree(worktree.path)
-    : { attempted: false };
-  const removalRoot = await resolveSafeRemovalRoot(context, worktree);
-
-  await removeGitWorktree(removalRoot.gitRoot, worktree.path);
-
-  if (options.keepBranch) {
     return {
+      target: worktree.path,
+      context,
       worktree,
-      branchDeleted: false,
-      relocatedToPath: removalRoot.relocatedToPath,
-      herdrWorkspaceId: herdr.workspaceId,
-      herdrError: herdr.error,
+      isCurrent,
+      ...status,
+      ...(displayedStatusEntries
+        ? {
+            statusEntries: displayedStatusEntries,
+            remainingStatusEntryCount: Math.max(
+              allStatusEntries.totalCount - displayedStatusEntries.length,
+              0
+            ),
+          }
+        : {}),
+      removalRoot,
+      revision: buildPlanRevision({
+        worktree,
+        isCurrent,
+        status,
+        statusEntries: allStatusEntries.entries,
+        removalRoot,
+      }),
     };
-  }
+  };
 
-  if (!worktree.branch) {
+  const executeForeground = async (
+    plan: RemovalPlan,
+    options: ExecuteRemovalOptions
+  ): Promise<RemovedWorktreeResult | BranchRemovalFailedResult> => {
+    const settings = await dependencies.settings.load(plan.context.repoRoot);
+    const herdr = await inspectHerdrForRemoval(
+      dependencies,
+      settings,
+      plan.worktree.path
+    );
+
+    if (plan.removalRoot.relocatedToPath) {
+      dependencies.runtime.changeDirectory(plan.removalRoot.relocatedToPath);
+    }
+
+    await dependencies.git.remove(
+      plan.removalRoot.gitRoot,
+      plan.worktree.path
+    );
+
+    let branchError: string | undefined;
+    let branchDeleted = false;
+
+    if (!options.keepBranch && plan.worktree.branch) {
+      try {
+        await dependencies.git.deleteBranch(
+          plan.removalRoot.gitRoot,
+          plan.worktree.branch
+        );
+        branchDeleted = true;
+      } catch (error) {
+        branchError = getErrorMessage(error);
+      }
+    }
+
+    const warnings = await closeHerdrAfterRemoval(dependencies, herdr);
+
+    if (branchError) {
+      return {
+        status: "worktree_removed_branch_failed",
+        worktree: plan.worktree,
+        relocatedToPath: plan.removalRoot.relocatedToPath,
+        error: branchError,
+        warnings,
+      };
+    }
+
     return {
-      worktree,
-      branchDeleted: false,
-      relocatedToPath: removalRoot.relocatedToPath,
-      herdrWorkspaceId: herdr.workspaceId,
-      herdrError: herdr.error,
+      status: "removed",
+      worktree: plan.worktree,
+      branchDeleted,
+      relocatedToPath: plan.removalRoot.relocatedToPath,
+      warnings,
     };
-  }
-
-  try {
-    await deleteBranch(removalRoot.gitRoot, worktree.branch);
-  } catch (error) {
-    throw new RemoveWorktreeError(
-      getErrorMessage(error),
-      removalRoot.relocatedToPath
-    );
-  }
-
-  return {
-    worktree,
-    branchDeleted: true,
-    relocatedToPath: removalRoot.relocatedToPath,
-    herdrWorkspaceId: herdr.workspaceId,
-    herdrError: herdr.error,
   };
+
+  const executeBackground = async (
+    plan: RemovalPlan,
+    options: ExecuteRemovalOptions
+  ): Promise<BackgroundRemovalResult> => {
+    if (!plan.removalRoot.relocatedToPath) {
+      throw new AppError(
+        "Could not find another worktree to remove this worktree safely"
+      );
+    }
+
+    const settings = await dependencies.settings.load(plan.context.repoRoot);
+    const herdr = await inspectHerdrForRemoval(
+      dependencies,
+      settings,
+      plan.worktree.path
+    );
+    await dependencies.settings.ensureTaskArtifactsIgnored(
+      plan.removalRoot.relocatedToPath
+    );
+    const { statusFilePath, logFilePath } = buildRemovalTaskPaths(
+      dependencies,
+      plan.removalRoot.relocatedToPath,
+      plan.worktree
+    );
+    const pid = dependencies.tasks.start({
+      scripts: buildRemovalTaskScripts(
+        plan.removalRoot.gitRoot,
+        plan.worktree,
+        options
+      ),
+      cwd: plan.removalRoot.gitRoot,
+      env: {
+        WT_ID: plan.worktree.id,
+        WT_PATH: plan.worktree.path,
+        ...(plan.worktree.branch
+          ? { WT_BRANCH: plan.worktree.branch }
+          : {}),
+      },
+      statusFilePath,
+      logFilePath,
+      statusMetadata: {
+        kind: "remove-worktree",
+        worktreeId: plan.worktree.id,
+        worktreePath: plan.worktree.path,
+        branch: plan.worktree.branch,
+      },
+      startNotification:
+        dependencies.runtime.platform === "darwin"
+          ? buildRemovalStartNotification(plan.worktree)
+          : undefined,
+      completionNotification:
+        dependencies.runtime.platform === "darwin"
+          ? buildRemovalCompletionNotification(plan.worktree)
+          : undefined,
+    });
+    const warnings = await closeHerdrAfterRemoval(dependencies, herdr);
+
+    return {
+      status: "background_started",
+      worktree: plan.worktree,
+      branchDeleteQueued: Boolean(
+        plan.worktree.branch && !options.keepBranch
+      ),
+      relocatedToPath: plan.removalRoot.relocatedToPath,
+      pid,
+      statusFilePath,
+      logFilePath,
+      warnings,
+    };
+  };
+
+  const execute = async (
+    plan: RemovalPlan,
+    options: ExecuteRemovalOptions
+  ): Promise<RemovalResult> => {
+    let latestPlan: RemovalPlan;
+
+    try {
+      latestPlan = await inspect(plan.target, plan.context.cwd, {
+        includeStatusEntries: plan.statusEntries !== undefined,
+        statusEntryLimit: plan.statusEntries?.length,
+      });
+    } catch (error) {
+      return {
+        status: "plan_stale",
+        reason: getErrorMessage(error),
+      };
+    }
+
+    if (latestPlan.revision !== plan.revision) {
+      return {
+        status: "plan_stale",
+        latestPlan,
+        reason: "Worktree state changed after removal was approved",
+      };
+    }
+
+    const shouldRunInBackground =
+      options.execution === "auto" &&
+      latestPlan.isCurrent &&
+      !latestPlan.worktree.isMain;
+
+    return shouldRunInBackground
+      ? executeBackground(latestPlan, options)
+      : executeForeground(latestPlan, options);
+  };
+
+  return { inspect, execute };
 }
 
-export async function removeCurrentWorktreeInBackground(
-  target: string,
-  options: RemoveWorktreeOptions,
-  cwd: string = process.cwd()
-): Promise<BackgroundRemoveWorktreeResult> {
-  const { context, worktree } = await resolveRemovalTarget(target, cwd);
-  const settings = await loadSettings(context.repoRoot);
-  const herdr = settings.herdr.closeWorkspaceOnRemove
-    ? await findHerdrWorkspaceForWorktree(worktree.path)
-    : { attempted: false };
+const defaultRemoval = createWorktreeRemoval(defaultDependencies);
 
-  if (!isPathInside(worktree.path, context.cwd)) {
-    throw new AppError(
-      "Background removal is only available for the current worktree"
-    );
-  }
-
-  const removalRoot = await findSafeRemovalRoot(context, worktree);
-
-  if (!removalRoot.relocatedToPath) {
-    throw new AppError(
-      "Could not find another worktree to remove this worktree safely"
-    );
-  }
-
-  await ensureRemoveTaskArtifactsIgnored(removalRoot.relocatedToPath);
-
-  const { statusFilePath, logFilePath } = buildRemovalTaskPaths(
-    removalRoot.relocatedToPath,
-    worktree
-  );
-  const scripts = buildRemovalTaskScripts(
-    removalRoot.gitRoot,
-    worktree,
-    options
-  );
-  const pid = executeDetachedTask({
-    scripts,
-    cwd: removalRoot.gitRoot,
-    env: {
-      WT_ID: worktree.id,
-      WT_PATH: worktree.path,
-      ...(worktree.branch ? { WT_BRANCH: worktree.branch } : {}),
-    },
-    statusFilePath,
-    logFilePath,
-    statusMetadata: {
-      kind: "remove-worktree",
-      worktreeId: worktree.id,
-      worktreePath: worktree.path,
-      branch: worktree.branch,
-    },
-    startNotification:
-      process.platform === "darwin"
-        ? buildRemovalStartNotification(worktree)
-        : undefined,
-    completionNotification:
-      process.platform === "darwin"
-        ? buildRemovalCompletionNotification(worktree)
-        : undefined,
-  });
-
-  return {
-    worktree,
-    branchDeleteQueued: Boolean(worktree.branch && !options.keepBranch),
-    relocatedToPath: removalRoot.relocatedToPath,
-    pid,
-    statusFilePath,
-    logFilePath,
-    herdrWorkspaceId: herdr.workspaceId,
-    herdrError: herdr.error,
-  };
-}
+export const inspectRemoval = defaultRemoval.inspect;
+export const executeRemoval = defaultRemoval.execute;

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -7,8 +7,8 @@ import {
   planWorktreeCleanup,
 } from "../app/use-cases/clean-worktrees.js";
 import {
-  inspectRemoveWorktree,
-  type RemoveWorktreePreview,
+  inspectRemoval,
+  type RemovalPlan,
 } from "../app/use-cases/remove-worktree.js";
 import { promptMultiSelect } from "../cli/multi-select.js";
 import { runCommand } from "../cli/command-runtime.js";
@@ -38,7 +38,7 @@ interface CleanupPickerEntry {
 }
 
 interface CleanupPreviewEntry extends CleanupPickerEntry {
-  preview: RemoveWorktreePreview;
+  preview: RemovalPlan;
 }
 
 const WIDE_LAYOUT_MIN_COLUMNS = 140;
@@ -166,7 +166,7 @@ function buildPickerLabel(entry: CleanupPickerEntry): string {
 
 function buildPickerDetails(
   entry: CleanupPickerEntry,
-  preview: RemoveWorktreePreview
+  preview: RemovalPlan
 ): string[] {
   const idDisplay = buildWorktreeIdLabel({
     id: entry.candidate.worktree.id,
@@ -236,7 +236,7 @@ function buildCleanupPickerEntries(
 }
 
 function canUseCachedPreview(
-  preview: RemoveWorktreePreview,
+  preview: RemovalPlan,
   includeStatusEntries: boolean
 ): boolean {
   if (!includeStatusEntries) {
@@ -248,11 +248,11 @@ function canUseCachedPreview(
 
 async function loadCachedPreview(
   entry: CleanupPickerEntry,
-  previewCache: Map<string, RemoveWorktreePreview>,
+  previewCache: Map<string, RemovalPlan>,
   options: {
     includeStatusEntries?: boolean;
   } = {}
-): Promise<RemoveWorktreePreview> {
+): Promise<RemovalPlan> {
   const includeStatusEntries = options.includeStatusEntries === true;
   const cachedPreview = previewCache.get(entry.candidate.worktree.id);
 
@@ -260,7 +260,7 @@ async function loadCachedPreview(
     return cachedPreview;
   }
 
-  const preview = await inspectRemoveWorktree(entry.candidate.worktree.id, process.cwd(), {
+  const preview = await inspectRemoval(entry.candidate.worktree.id, process.cwd(), {
     includeStatusEntries,
   });
   previewCache.set(entry.candidate.worktree.id, preview);
@@ -269,7 +269,7 @@ async function loadCachedPreview(
 
 async function attachCleanupPreviews(
   entries: CleanupPickerEntry[],
-  previewCache: Map<string, RemoveWorktreePreview>
+  previewCache: Map<string, RemovalPlan>
 ): Promise<CleanupPreviewEntry[]> {
   return Promise.all(
     entries.map(async (entry) => ({
@@ -327,7 +327,7 @@ function renderCleanupPreview(
 async function selectCleanupEntries(
   repoName: string,
   entries: CleanupPickerEntry[],
-  previewCache: Map<string, RemoveWorktreePreview>
+  previewCache: Map<string, RemovalPlan>
 ): Promise<CleanupPickerEntry[] | undefined> {
   const result = await promptMultiSelect(
     entries.map((entry) => ({
@@ -362,7 +362,7 @@ export async function cleanCommand(
   options: CleanCommandOptions
 ): Promise<void> {
   await runCommand(async () => {
-    const previewCache = new Map<string, RemoveWorktreePreview>();
+    const previewCache = new Map<string, RemovalPlan>();
     assertInteractiveTerminal();
 
     const plan = await planWorktreeCleanup(

--- a/src/commands/remove-shared.ts
+++ b/src/commands/remove-shared.ts
@@ -3,12 +3,12 @@ import { createInterface } from "readline/promises";
 import { AppError } from "../app/errors.js";
 import { getWorktreeBranchLabel } from "../domain/worktree.js";
 import {
-  type BackgroundRemoveWorktreeResult,
-  closeRemovedWorktreeInHerdr,
-  inspectRemoveWorktree,
-  removeCurrentWorktreeInBackground,
-  RemoveWorktreeError,
-  removeWorktree,
+  executeRemoval,
+  inspectRemoval,
+  type BackgroundRemovalResult,
+  type RemovalPlan,
+  type RemovalResult,
+  type RemovedWorktreeResult,
 } from "../app/use-cases/remove-worktree.js";
 import { runWithSpinner } from "../cli/spinner.js";
 import { emitShellCd } from "../infra/shell/cd.js";
@@ -22,6 +22,13 @@ export interface RemoveCommandOptions {
 export interface RemovalPrompter {
   confirmCleanup: (worktreeCount: number) => Promise<boolean>;
   confirmRemoval: (
+    worktreeId: string,
+    branch: string,
+    localChangeCount: number,
+    localCommitCount: number,
+    hasUnknownLocalCommits: boolean
+  ) => Promise<boolean>;
+  confirmChangedRemoval: (
     worktreeId: string,
     branch: string,
     localChangeCount: number,
@@ -185,6 +192,28 @@ export function createRemovalPrompter(): RemovalPrompter {
 
       return confirmAction("Remove this worktree anyway? [y/N] ");
     },
+    async confirmChangedRemoval(
+      worktreeId: string,
+      branch: string,
+      localChangeCount: number,
+      localCommitCount: number,
+      hasUnknownLocalCommits: boolean
+    ): Promise<boolean> {
+      const summary = buildPendingWorkSummary(
+        localChangeCount,
+        localCommitCount,
+        hasUnknownLocalCommits
+      );
+      const pendingMessage = summary ? ` It now has ${summary}.` : "";
+
+      console.log(
+        chalk.yellow(
+          `Warning: ${branch} (${worktreeId}) changed after confirmation.${pendingMessage}`
+        )
+      );
+
+      return confirmAction("Review the latest state and remove it anyway? [y/N] ");
+    },
     close() {
       readline?.close();
       if (dataHandlerAttached) {
@@ -196,7 +225,7 @@ export function createRemovalPrompter(): RemovalPrompter {
 }
 
 export function hasPendingWork(
-  preview: Awaited<ReturnType<typeof inspectRemoveWorktree>>
+  preview: RemovalPlan
 ): boolean {
   return (
     preview.localChangeCount > 0 ||
@@ -206,7 +235,7 @@ export function hasPendingWork(
 }
 
 export function logRemovalResult(
-  result: Awaited<ReturnType<typeof removeWorktree>>
+  result: RemovedWorktreeResult
 ): void {
   const branchLabel = getWorktreeBranchLabel(result.worktree);
 
@@ -228,7 +257,7 @@ export function logRemovalResult(
 }
 
 export function logBackgroundRemovalResult(
-  result: BackgroundRemoveWorktreeResult
+  result: BackgroundRemovalResult
 ): void {
   const branchLabel = getWorktreeBranchLabel(result.worktree);
 
@@ -254,22 +283,58 @@ export function logBackgroundRemovalResult(
   emitShellCd(result.relocatedToPath);
 }
 
+function logRemovalWarnings(result: {
+  warnings: Array<{ message: string }>;
+}): void {
+  for (const warning of result.warnings) {
+    console.error(chalk.yellow(`Warning: ${warning.message}`));
+  }
+}
+
+async function executeRemovalWithProgress(
+  plan: RemovalPlan,
+  options: RemoveCommandOptions,
+  batchMode: boolean
+): Promise<RemovalResult> {
+  const execution =
+    batchMode || options.foreground ? "foreground" : "auto";
+  const shouldShowSpinner =
+    execution === "foreground" || !plan.isCurrent || plan.worktree.isMain;
+
+  if (!shouldShowSpinner) {
+    return executeRemoval(plan, {
+      keepBranch: options.keepBranch,
+      execution,
+    });
+  }
+
+  const branchLabel = getWorktreeBranchLabel(plan.worktree);
+  return runWithSpinner(
+    `Removing worktree ${branchLabel} (${plan.worktree.id})`,
+    () =>
+      executeRemoval(plan, {
+        keepBranch: options.keepBranch,
+        execution,
+      })
+  );
+}
+
 export async function removeSingleWorktree(
   id: string,
   options: RemoveCommandOptions,
   batchMode: boolean,
   prompter: RemovalPrompter
 ): Promise<"removed" | "skipped"> {
-  const preview = await inspectRemoveWorktree(id);
-  const branchLabel = getWorktreeBranchLabel(preview.worktree);
+  let plan = await inspectRemoval(id);
+  let branchLabel = getWorktreeBranchLabel(plan.worktree);
 
-  if (hasPendingWork(preview) && !options.force) {
+  if (hasPendingWork(plan) && !options.force) {
     const confirmed = await prompter.confirmRemoval(
-      preview.worktree.id,
+      plan.worktree.id,
       branchLabel,
-      preview.localChangeCount,
-      preview.localCommitCount,
-      preview.hasUnknownLocalCommits
+      plan.localChangeCount,
+      plan.localCommitCount,
+      plan.hasUnknownLocalCommits
     );
 
     if (!confirmed) {
@@ -279,59 +344,65 @@ export async function removeSingleWorktree(
 
       console.log(
         chalk.yellow(
-          `Skipped worktree: ${branchLabel} (${preview.worktree.id})`
+          `Skipped worktree: ${branchLabel} (${plan.worktree.id})`
         )
       );
       return "skipped";
     }
   }
 
-  if (
-    preview.isCurrent &&
-    !preview.worktree.isMain &&
-    !batchMode &&
-    !options.foreground
-  ) {
-    const result = await removeCurrentWorktreeInBackground(id, options);
-    logBackgroundRemovalResult(result);
-    await closeHerdrAfterRemoval(result);
-    return "removed";
-  }
+  while (true) {
+    const result = await executeRemovalWithProgress(plan, options, batchMode);
 
-  const result = await runWithSpinner(
-    `Removing worktree ${branchLabel} (${preview.worktree.id})`,
-    async () => {
-      try {
-        return await removeWorktree(preview.worktree.id, options);
-      } catch (error) {
-        if (error instanceof RemoveWorktreeError && error.relocatedToPath) {
-          emitShellCd(error.relocatedToPath);
-        }
-
-        throw error;
+    if (result.status === "plan_stale") {
+      if (!result.latestPlan) {
+        throw new AppError(result.reason);
       }
+
+      plan = result.latestPlan;
+      branchLabel = getWorktreeBranchLabel(plan.worktree);
+
+      if (!options.force) {
+        const confirmed = await prompter.confirmChangedRemoval(
+          plan.worktree.id,
+          branchLabel,
+          plan.localChangeCount,
+          plan.localCommitCount,
+          plan.hasUnknownLocalCommits
+        );
+
+        if (!confirmed) {
+          if (!batchMode) {
+            throw new AppError("Removal cancelled");
+          }
+
+          console.log(
+            chalk.yellow(
+              `Skipped worktree: ${branchLabel} (${plan.worktree.id})`
+            )
+          );
+          return "skipped";
+        }
+      }
+
+      continue;
     }
-  );
-  logRemovalResult(result);
-  await closeHerdrAfterRemoval(result);
-  return "removed";
-}
 
-async function closeHerdrAfterRemoval(result: {
-  herdrWorkspaceId?: string;
-  herdrError?: string;
-}): Promise<void> {
-  if (result.herdrError) {
-    console.error(
-      chalk.yellow(`Warning: Could not find Herdr workspace: ${result.herdrError}`)
-    );
-    return;
-  }
+    if (result.status === "worktree_removed_branch_failed") {
+      logRemovalWarnings(result);
+      if (result.relocatedToPath) {
+        emitShellCd(result.relocatedToPath);
+      }
+      throw new AppError(result.error);
+    }
 
-  const herdr = await closeRemovedWorktreeInHerdr(result.herdrWorkspaceId);
-  if (herdr.error) {
-    console.error(
-      chalk.yellow(`Warning: Could not close Herdr workspace: ${herdr.error}`)
-    );
+    if (result.status === "background_started") {
+      logBackgroundRemovalResult(result);
+    } else {
+      logRemovalResult(result);
+    }
+    logRemovalWarnings(result);
+
+    return "removed";
   }
 }


### PR DESCRIPTION
## Summary

- centralize removal inspection, stale-plan validation, foreground/background execution, runtime relocation, and Herdr cleanup in one application lifecycle
- return explicit tagged outcomes for stale plans, background starts, successful removals, and partial branch-deletion failures
- keep remove/clean terminal interaction in the command layer while sharing the same single-target application seam

## Verification

- bun run typecheck
- bun test (226 pass, 0 fail)