### PR TITLE
fix: stream wt output in Herdr plugin

### DIFF
--- a/.changeset/live-herdr-output.md
+++ b/.changeset/live-herdr-output.md
@@ -1,0 +1,5 @@
+---
+"@leesangb/wt": patch
+---
+
+Stream worktree creation progress in the Herdr plugin while retaining the final structured result for opening the new workspace.

--- a/src/herdr-plugin/index.test.ts
+++ b/src/herdr-plugin/index.test.ts
@@ -8,6 +8,7 @@ import {
   encodeLaunchContext,
   parsePluginContext,
   parseWtJsonOutput,
+  streamAndCaptureOutput,
 } from "./index.js";
 
 describe("wt Herdr plugin", () => {
@@ -124,5 +125,44 @@ describe("wt Herdr plugin", () => {
       path: "/tmp/repo-feature-a",
       branch: "feature/a",
     });
+  });
+
+  test("forwards wt output before the command finishes while retaining it for parsing", async () => {
+    const encoder = new TextEncoder();
+    let finishStream = () => {};
+    let markFirstWrite = () => {};
+    const firstWrite = new Promise<void>((resolve) => {
+      markFirstWrite = resolve;
+    });
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("Creating worktree...\n"));
+        finishStream = () => {
+          controller.enqueue(
+            encoder.encode(
+              '{"id":"feature-a","path":"/tmp/feature-a","branch":"feature/a"}\n'
+            )
+          );
+          controller.close();
+        };
+      },
+    });
+    const forwarded: string[] = [];
+
+    const capturedOutput = streamAndCaptureOutput(stream, {
+      write(chunk) {
+        forwarded.push(new TextDecoder().decode(chunk));
+        markFirstWrite();
+        return true;
+      },
+    });
+
+    await firstWrite;
+    expect(forwarded).toEqual(["Creating worktree...\n"]);
+
+    finishStream();
+    expect(await capturedOutput).toBe(
+      'Creating worktree...\n{"id":"feature-a","path":"/tmp/feature-a","branch":"feature/a"}\n'
+    );
   });
 });

--- a/src/herdr-plugin/index.ts
+++ b/src/herdr-plugin/index.ts
@@ -98,9 +98,32 @@ export function parseWtJsonOutput(output: string): WtJsonResult {
   throw new Error("wt did not return a worktree JSON result");
 }
 
+export async function streamAndCaptureOutput(
+  stream: ReadableStream<Uint8Array>,
+  output: { write(chunk: Uint8Array): unknown }
+): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let captured = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    output.write(value);
+    captured += decoder.decode(value, { stream: true });
+  }
+
+  return captured + decoder.decode();
+}
+
 async function run(
   command: string[],
-  options: { cwd?: string; capture?: boolean } = {}
+  options: {
+    cwd?: string;
+    capture?: boolean;
+    streamCapturedOutput?: boolean;
+  } = {}
 ): Promise<string> {
   const proc = spawn(command, {
     cwd: options.cwd,
@@ -109,7 +132,14 @@ async function run(
     stdout: options.capture ? "pipe" : "inherit",
     stderr: "inherit",
   });
-  const stdout = options.capture ? await new Response(proc.stdout).text() : "";
+  const stdout = options.capture
+    ? options.streamCapturedOutput
+      ? await streamAndCaptureOutput(
+          proc.stdout as ReadableStream<Uint8Array>,
+          process.stdout
+        )
+      : await new Response(proc.stdout).text()
+    : "";
   const exitCode = await proc.exited;
 
   if (exitCode !== 0) {
@@ -493,6 +523,7 @@ async function runUi(): Promise<void> {
     const output = await run(wtArgs, {
       cwd: context.cwd,
       capture: true,
+      streamCapturedOutput: true,
     });
     const result = parseWtJsonOutput(output);
     const herdr = process.env.HERDR_BIN_PATH ?? "herdr";


### PR DESCRIPTION
## Summary

- forward wt stdout chunks to the Herdr overlay as soon as they arrive
- retain the same output for parsing the final structured worktree result
- limit streaming to wt new, checkout, and pr so internal captured JSON remains hidden elsewhere

## Verification

- bun test src/herdr-plugin/index.test.ts
- bun run typecheck
- bun run build:herdr-plugin
- bun test (229 pass, 0 fail)