### PR TITLE
feat: show live PR status in Herdr spaces

### DIFF
--- a/.changeset/live-herdr-pr-status.md
+++ b/.changeset/live-herdr-pr-status.md
@@ -1,5 +1,5 @@
 ---
-"@leesangb/wt": minor
+"@leesangb/wt": patch
 ---
 
 Show live pull request and CI status in Herdr Space rows and add an action that opens the selected workspace's pull request in a browser.

--- a/.changeset/live-herdr-pr-status.md
+++ b/.changeset/live-herdr-pr-status.md
@@ -1,0 +1,5 @@
+---
+"@leesangb/wt": minor
+---
+
+Show live pull request and CI status in Herdr Space rows and add an action that opens the selected workspace's pull request in a browser.

--- a/README.ko.md
+++ b/README.ko.md
@@ -73,12 +73,45 @@ herdr plugin install leesangb/wt
 - `wt.herdr.checkout` — 기존 로컬 브랜치를 worktree로 열기
 - `wt.herdr.pr` — Pull Request worktree 생성 또는 재사용
 - `wt.herdr.open-all` — 아직 열리지 않은 기존 checkout 모두 열기
+- `wt.herdr.open-pr` — 선택한 Space의 Pull Request를 브라우저에서 열기
+- `wt.herdr.watch-pr` — 기존 Space의 Pull Request 라이브 상태 시작
 
 새 worktree 액션은 새 브랜치에 일반 텍스트 입력을, base branch에 `fzf`를
 사용합니다. Checkout은 로컬 브랜치를 보여주고, PR은 열린 GitHub PR의 제목,
 작성자, head branch, Draft 상태를 보여줍니다. 어느 단계에서든 `Esc`를 누르면
 취소됩니다. `fzf`가 `PATH`에 있어야 하며 PR picker에는 인증된 GitHub CLI
 (`gh`)가 필요합니다.
+
+새로 연 worktree Space는 연결된 Pull Request와 CI 상태를 자동으로 감시합니다.
+확장된 Space 행에 메타데이터 토큰을 추가하세요:
+
+```toml
+[ui.sidebar.spaces]
+rows = [
+  ["state_icon", "workspace"],
+  ["branch", "git_status"],
+  ["$pr", "$ci"],
+]
+```
+
+Pull Request는 Open이면 `🟢 #123`, Draft이면 `⚪ #123`, Merge되면
+`🟣 #123`, 닫히면 `🔴 #123`으로 표시됩니다. CI 상태는 `✅`, `🟡`,
+`❌` 중 하나로만 표시됩니다. 플러그인을 설치하거나 Herdr 서버를 재시작하기
+전에 이미 열려 있던 Space에서는 `wt.herdr.watch-pr`을 한 번 실행하세요. 진행 중인
+check는 GitHub CLI watch mode로 완료 즉시 갱신됩니다. Space를 focus하면 바로
+새로고침하며, 안정 상태에서는 5분 간격으로만 안전 확인하고 장애 중에는 오래된
+값이 만료됩니다.
+
+Herdr 메타데이터 토큰은 표시 전용이므로 선택한 Space의 PR로 이동할 때는
+`wt.herdr.open-pr` 액션을 사용합니다. 원하면 단축키를 바로 연결할 수 있습니다:
+
+```toml
+[[keys.command]]
+key = "prefix+alt+o"
+type = "plugin_action"
+command = "wt.herdr.open-pr"
+description = "Open this Space's pull request"
+```
 
 Herdr pane 안에서 `wt new`, `wt checkout`, `wt pr`을 실행하면 결과 checkout을
 Herdr worktree workspace로 즉시 열고 focus합니다. `--no-cd`를 사용하면 workspace를
@@ -102,7 +135,7 @@ herdr server reload-config
 ```
 
 설치된 플러그인은 같은 revision의 `wt` 소스를 직접 빌드해서 사용하므로 별도로
-설치된 `wt` 바이너리에 의존하지 않습니다. 플러그인 설치 시 Herdr `>= 0.7.0`과
+설치된 `wt` 바이너리에 의존하지 않습니다. 플러그인 설치 시 Herdr `>= 0.7.4`과
 Bun이 필요합니다.
 
 ### 수동 Shell 통합 (선택사항)

--- a/README.md
+++ b/README.md
@@ -73,12 +73,45 @@ The plugin provides these actions:
 - `wt.herdr.checkout` — open an existing local branch as a worktree
 - `wt.herdr.pr` — create or reuse a pull request worktree
 - `wt.herdr.open-all` — open every existing checkout that is not already open
+- `wt.herdr.open-pr` — open the selected Space's pull request in a browser
+- `wt.herdr.watch-pr` — start live pull request status for an existing Space
 
 The new-worktree action uses a text prompt for the new branch and `fzf` for the
 base branch. Checkout lists local branches, while PR lists open GitHub pull
 requests with title, author, head branch, and draft status. Press `Esc` at any
 step to cancel. The plugin requires `fzf` on `PATH`, and the PR picker requires
 an authenticated GitHub CLI (`gh`).
+
+Newly opened worktree Spaces automatically watch their linked pull request and
+CI status. Add the metadata tokens to the expanded Space rows:
+
+```toml
+[ui.sidebar.spaces]
+rows = [
+  ["state_icon", "workspace"],
+  ["branch", "git_status"],
+  ["$pr", "$ci"],
+]
+```
+
+Pull requests appear as `🟢 #123` when open, `⚪ #123` when draft,
+`🟣 #123` when merged, and `🔴 #123` when closed. CI is reduced to `✅`,
+`🟡`, or `❌`. Run `wt.herdr.watch-pr` once for a Space that was already open
+when the plugin was installed or the Herdr server restarted. Pending checks use
+GitHub CLI's watch mode and update as soon as they finish. Focusing a Space
+refreshes it immediately; stable states use a five-minute safety refresh, and
+stale values expire during an outage.
+
+Herdr metadata tokens are display-only, so open the selected Space's pull
+request with the `wt.herdr.open-pr` action. You can optionally bind it directly:
+
+```toml
+[[keys.command]]
+key = "prefix+alt+o"
+type = "plugin_action"
+command = "wt.herdr.open-pr"
+description = "Open this Space's pull request"
+```
 
 When `wt new`, `wt checkout`, or `wt pr` runs inside a Herdr pane, `wt`
 automatically opens the resulting checkout as a focused Herdr worktree workspace.
@@ -103,7 +136,7 @@ herdr server reload-config
 
 The installed plugin builds and uses the `wt` source from the same revision, so
 it does not depend on a separately installed `wt` binary. It requires Herdr
-`>= 0.7.0` and Bun during plugin installation.
+`>= 0.7.4` and Bun during plugin installation.
 
 ### Manual Shell Integration (Optional)
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,8 +1,8 @@
 id = "wt.herdr"
 name = "wt for Herdr"
-version = "0.6.0"
-min_herdr_version = "0.7.0"
-description = "Create and open wt-managed Git worktrees as grouped Herdr workspaces."
+version = "0.7.0"
+min_herdr_version = "0.7.4"
+description = "Manage wt worktrees in Herdr with live GitHub pull request and CI status."
 platforms = ["linux", "macos"]
 
 [[build]]
@@ -31,6 +31,26 @@ id = "open-all"
 title = "wt: Open all existing worktrees"
 contexts = ["workspace"]
 command = ["./.herdr-plugin/bin/wt-herdr", "open-all"]
+
+[[actions]]
+id = "open-pr"
+title = "wt: Open pull request in browser"
+contexts = ["workspace"]
+command = ["./.herdr-plugin/bin/wt-herdr", "open-pr"]
+
+[[actions]]
+id = "watch-pr"
+title = "wt: Watch pull request status"
+contexts = ["workspace"]
+command = ["./.herdr-plugin/bin/wt-herdr", "watch-context"]
+
+[[events]]
+on = "worktree.opened"
+command = ["./.herdr-plugin/bin/wt-herdr", "watch-event"]
+
+[[events]]
+on = "workspace.focused"
+command = ["./.herdr-plugin/bin/wt-herdr", "refresh-focused"]
 
 [[panes]]
 id = "create"

--- a/src/herdr-plugin/index.test.ts
+++ b/src/herdr-plugin/index.test.ts
@@ -4,10 +4,15 @@ import {
   buildBaseBranchChoices,
   buildPullRequestChoices,
   buildPullRequestHeader,
+  ciStatusToken,
   closedLinkedWorktrees,
   encodeLaunchContext,
+  parsePullRequestDetails,
+  parseWorkspaceFocusedEvent,
+  parseWorktreeOpenedEvent,
   parsePluginContext,
   parseWtJsonOutput,
+  pullRequestStatusToken,
   streamAndCaptureOutput,
 } from "./index.js";
 
@@ -164,5 +169,67 @@ describe("wt Herdr plugin", () => {
     expect(await capturedOutput).toBe(
       'Creating worktree...\n{"id":"feature-a","path":"/tmp/feature-a","branch":"feature/a"}\n'
     );
+  });
+
+  test("maps GitHub pull request states to compact colored indicators", () => {
+    expect(
+      pullRequestStatusToken(
+        parsePullRequestDetails(
+          '{"number":123,"url":"https://github.com/acme/app/pull/123","state":"OPEN","isDraft":false}'
+        )
+      )
+    ).toBe("🟢 #123");
+    expect(
+      pullRequestStatusToken(
+        parsePullRequestDetails(
+          '{"number":123,"url":"https://github.com/acme/app/pull/123","state":"OPEN","isDraft":true}'
+        )
+      )
+    ).toBe("⚪ #123");
+    expect(
+      pullRequestStatusToken(
+        parsePullRequestDetails(
+          '{"number":123,"url":"https://github.com/acme/app/pull/123","state":"MERGED","isDraft":false}'
+        )
+      )
+    ).toBe("🟣 #123");
+    expect(
+      pullRequestStatusToken(
+        parsePullRequestDetails(
+          '{"number":123,"url":"https://github.com/acme/app/pull/123","state":"CLOSED","isDraft":false}'
+        )
+      )
+    ).toBe("🔴 #123");
+  });
+
+  test("reduces check buckets to one CI status symbol", () => {
+    expect(ciStatusToken('[{"bucket":"pass"},{"bucket":"skipping"}]')).toBe("✅");
+    expect(ciStatusToken('[{"bucket":"pass"},{"bucket":"pending"}]')).toBe("🟡");
+    expect(ciStatusToken('[{"bucket":"pass"},{"bucket":"fail"}]')).toBe("❌");
+    expect(ciStatusToken('[{"bucket":"cancel"}]')).toBe("❌");
+    expect(ciStatusToken("[]")).toBeUndefined();
+  });
+
+  test("extracts the opened workspace and checkout from a Herdr event", () => {
+    expect(
+      parseWorktreeOpenedEvent(
+        JSON.stringify({
+          type: "worktree_opened",
+          workspace: {
+            workspace_id: "w3",
+            worktree: { checkout_path: "/worktrees/pr-123" },
+          },
+          worktree: { path: "/worktrees/pr-123" },
+        })
+      )
+    ).toEqual({ workspaceId: "w3", cwd: "/worktrees/pr-123" });
+  });
+
+  test("extracts a workspace id from a focused event envelope", () => {
+    expect(
+      parseWorkspaceFocusedEvent(
+        JSON.stringify({ event: { type: "workspace_focused", workspace_id: "w7" } })
+      )
+    ).toBe("w7");
   });
 });

--- a/src/herdr-plugin/index.ts
+++ b/src/herdr-plugin/index.ts
@@ -1,4 +1,14 @@
 import { spawn } from "bun";
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { join } from "path";
+import { readWorktreeMeta } from "../infra/storage/worktree-meta-store.js";
 
 export type WtMode = "new" | "checkout" | "pr";
 
@@ -34,6 +44,22 @@ interface PullRequest {
   isDraft: boolean;
 }
 
+export interface PullRequestDetails {
+  number: number;
+  url: string;
+  state: "OPEN" | "MERGED" | "CLOSED";
+  isDraft: boolean;
+}
+
+interface CheckStatus {
+  bucket: "pass" | "fail" | "pending" | "skipping" | "cancel";
+}
+
+interface WorkspaceWatchTarget {
+  workspaceId: string;
+  cwd: string;
+}
+
 interface HerdrWorktreeList {
   result: {
     source: { source_workspace_id: string };
@@ -49,6 +75,11 @@ interface HerdrWorktreeList {
 
 const ANSI_GRAY = "\x1b[90m";
 const ANSI_RESET = "\x1b[0m";
+const METADATA_SOURCE = "wt:github";
+const METADATA_TTL_MS = 600_000;
+const STABLE_REFRESH_INTERVAL_MS = 300_000;
+const RETRY_INTERVAL_MS = 60_000;
+const CHECK_WATCH_INTERVAL_SECONDS = 10;
 
 interface PullRequestColumnWidths {
   number: number;
@@ -162,6 +193,110 @@ async function capture(command: string[], cwd: string): Promise<string> {
   }
 
   return stdout;
+}
+
+async function captureWithExitCodes(
+  command: string[],
+  cwd: string,
+  acceptedExitCodes: number[]
+): Promise<string> {
+  const proc = spawn(command, { cwd, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  if (!acceptedExitCodes.includes(exitCode)) {
+    throw new Error(stderr.trim() || `${command[0]} exited with code ${exitCode}`);
+  }
+
+  return stdout;
+}
+
+export function parsePullRequestDetails(json: string): PullRequestDetails {
+  const value = JSON.parse(json) as Partial<PullRequestDetails>;
+
+  if (
+    typeof value.number !== "number" ||
+    typeof value.url !== "string" ||
+    !["OPEN", "MERGED", "CLOSED"].includes(value.state ?? "") ||
+    typeof value.isDraft !== "boolean"
+  ) {
+    throw new Error("GitHub returned invalid pull request details");
+  }
+
+  return value as PullRequestDetails;
+}
+
+export function pullRequestStatusToken(pullRequest: PullRequestDetails): string {
+  const indicator =
+    pullRequest.state === "MERGED"
+      ? "🟣"
+      : pullRequest.state === "CLOSED"
+        ? "🔴"
+        : pullRequest.isDraft
+          ? "⚪"
+          : "🟢";
+
+  return `${indicator} #${pullRequest.number}`;
+}
+
+export function ciStatusToken(json: string): string | undefined {
+  const checks = JSON.parse(json) as CheckStatus[];
+  if (!Array.isArray(checks) || checks.length === 0) return undefined;
+
+  if (checks.some(({ bucket }) => bucket === "fail" || bucket === "cancel")) {
+    return "❌";
+  }
+  if (checks.some(({ bucket }) => bucket === "pending")) {
+    return "🟡";
+  }
+  if (checks.every(({ bucket }) => bucket === "pass" || bucket === "skipping")) {
+    return "✅";
+  }
+
+  return "🟡";
+}
+
+export function parseWorktreeOpenedEvent(json: string): WorkspaceWatchTarget {
+  const envelope = JSON.parse(json) as {
+    workspace?: {
+      workspace_id?: string;
+      worktree?: { checkout_path?: string };
+    };
+    worktree?: { path?: string };
+    event?: {
+      workspace?: {
+        workspace_id?: string;
+        worktree?: { checkout_path?: string };
+      };
+      worktree?: { path?: string };
+    };
+  };
+  const event = envelope.event ?? envelope;
+  const workspaceId = event.workspace?.workspace_id;
+  const cwd = event.worktree?.path ?? event.workspace?.worktree?.checkout_path;
+
+  if (!workspaceId || !cwd) {
+    throw new Error("Herdr worktree event is missing workspace context");
+  }
+
+  return { workspaceId, cwd };
+}
+
+export function parseWorkspaceFocusedEvent(json: string): string {
+  const envelope = JSON.parse(json) as {
+    workspace_id?: string;
+    event?: { workspace_id?: string };
+  };
+  const workspaceId = envelope.event?.workspace_id ?? envelope.workspace_id;
+
+  if (!workspaceId) {
+    throw new Error("Herdr workspace event is missing a workspace id");
+  }
+
+  return workspaceId;
 }
 
 export function buildBaseBranchChoices(refs: string): BranchRef[] {
@@ -498,6 +633,277 @@ async function openAll(): Promise<void> {
   await run([herdr, "notification", "show", "wt", "--body", body]);
 }
 
+async function loadPullRequestDetails(cwd: string): Promise<PullRequestDetails> {
+  const meta = await readWorktreeMeta(cwd);
+  const args = ["gh", "pr", "view"];
+  if (meta?.prNumber) args.push(meta.prNumber);
+  args.push("--json", "number,url,state,isDraft");
+
+  return parsePullRequestDetails(await capture(args, cwd));
+}
+
+async function loadCiStatus(
+  pullRequest: PullRequestDetails,
+  cwd: string
+): Promise<string | undefined> {
+  const json = await captureWithExitCodes(
+    [
+      "gh",
+      "pr",
+      "checks",
+      String(pullRequest.number),
+      "--json",
+      "bucket",
+    ],
+    cwd,
+    [0, 8]
+  );
+
+  return ciStatusToken(json);
+}
+
+async function reportPullRequestStatus(
+  target: WorkspaceWatchTarget,
+  pullRequest: PullRequestDetails,
+  ci: string | undefined | null
+): Promise<void> {
+  const herdr = process.env.HERDR_BIN_PATH ?? "herdr";
+  const args = [
+    herdr,
+    "workspace",
+    "report-metadata",
+    target.workspaceId,
+    "--source",
+    METADATA_SOURCE,
+    "--token",
+    `pr=${pullRequestStatusToken(pullRequest)}`,
+    "--seq",
+    String(Date.now()),
+    "--ttl-ms",
+    String(METADATA_TTL_MS),
+  ];
+  if (ci !== null) {
+    args.push(ci ? "--token" : "--clear-token", ci ? `ci=${ci}` : "ci");
+  }
+
+  await captureWithExitCodes(args, target.cwd, [0]);
+}
+
+async function workspaceExists(target: WorkspaceWatchTarget): Promise<boolean> {
+  const herdr = process.env.HERDR_BIN_PATH ?? "herdr";
+
+  try {
+    await captureWithExitCodes(
+      [herdr, "workspace", "get", target.workspaceId],
+      target.cwd,
+      [0]
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function loadWorkspaceTarget(
+  workspaceId: string
+): Promise<WorkspaceWatchTarget | undefined> {
+  const herdr = process.env.HERDR_BIN_PATH ?? "herdr";
+  const json = await captureWithExitCodes(
+    [herdr, "workspace", "get", workspaceId],
+    process.cwd(),
+    [0]
+  );
+  const response = JSON.parse(json) as {
+    result?: {
+      workspace?: {
+        workspace_id?: string;
+        worktree?: { checkout_path?: string };
+      };
+    };
+  };
+  const workspace = response.result?.workspace;
+
+  if (!workspace?.workspace_id || !workspace.worktree?.checkout_path) {
+    return undefined;
+  }
+
+  return {
+    workspaceId: workspace.workspace_id,
+    cwd: workspace.worktree.checkout_path,
+  };
+}
+
+function watcherLockPath(workspaceId: string): string {
+  const stateDir = requiredEnv("HERDR_PLUGIN_STATE_DIR");
+  mkdirSync(stateDir, { recursive: true });
+  return join(stateDir, `github-status-${workspaceId.replaceAll(/[^A-Za-z0-9_-]/g, "-")}.pid`);
+}
+
+function processIsRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function acquireWatcherLock(workspaceId: string): (() => void) | undefined {
+  const lockPath = watcherLockPath(workspaceId);
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const fd = openSync(lockPath, "wx");
+      writeFileSync(fd, String(process.pid));
+      closeSync(fd);
+
+      return () => {
+        try {
+          if (readFileSync(lockPath, "utf8").trim() === String(process.pid)) {
+            unlinkSync(lockPath);
+          }
+        } catch {}
+      };
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") throw error;
+
+      try {
+        const existingPid = Number(readFileSync(lockPath, "utf8").trim());
+        if (Number.isInteger(existingPid) && processIsRunning(existingPid)) {
+          return undefined;
+        }
+        unlinkSync(lockPath);
+      } catch {
+        try {
+          unlinkSync(lockPath);
+        } catch {}
+      }
+    }
+  }
+
+  return undefined;
+}
+
+async function refreshPullRequestStatus(
+  target: WorkspaceWatchTarget
+): Promise<{ pullRequest: PullRequestDetails; ci: string | undefined | null }> {
+  const pullRequest = await loadPullRequestDetails(target.cwd);
+  let ci: string | undefined | null;
+
+  try {
+    ci = await loadCiStatus(pullRequest, target.cwd);
+  } catch {
+    // Keep the existing CI token until its TTL expires after a transient request failure.
+    ci = null;
+  }
+
+  await reportPullRequestStatus(target, pullRequest, ci);
+  return { pullRequest, ci };
+}
+
+async function waitForPendingChecks(
+  pullRequest: PullRequestDetails,
+  cwd: string
+): Promise<void> {
+  await captureWithExitCodes(
+    [
+      "gh",
+      "pr",
+      "checks",
+      String(pullRequest.number),
+      "--watch",
+      "--interval",
+      String(CHECK_WATCH_INTERVAL_SECONDS),
+      "--json",
+      "bucket",
+    ],
+    cwd,
+    [0, 1]
+  );
+}
+
+async function watchPullRequestStatus(target: WorkspaceWatchTarget): Promise<void> {
+  const releaseLock = acquireWatcherLock(target.workspaceId);
+  if (!releaseLock) return;
+
+  const stop = () => {
+    releaseLock();
+    process.exit(0);
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+  let consecutiveFailures = 0;
+
+  try {
+    while (await workspaceExists(target)) {
+      try {
+        const status = await refreshPullRequestStatus(target);
+        consecutiveFailures = 0;
+        if (status.ci === "🟡") {
+          try {
+            await waitForPendingChecks(status.pullRequest, target.cwd);
+          } catch {}
+          continue;
+        }
+        await Bun.sleep(STABLE_REFRESH_INTERVAL_MS);
+      } catch {
+        // Metadata has a TTL, so stale GitHub data disappears during outages.
+        consecutiveFailures += 1;
+        if (consecutiveFailures >= 3) break;
+        await Bun.sleep(RETRY_INTERVAL_MS);
+      }
+    }
+  } finally {
+    releaseLock();
+  }
+}
+
+async function watchEvent(): Promise<void> {
+  await watchPullRequestStatus(
+    parseWorktreeOpenedEvent(requiredEnv("HERDR_PLUGIN_EVENT_JSON"))
+  );
+}
+
+async function watchContext(): Promise<void> {
+  const context = parsePluginContext(
+    requiredEnv("HERDR_PLUGIN_CONTEXT_JSON"),
+    "pr"
+  );
+  await watchPullRequestStatus({
+    workspaceId: context.workspaceId,
+    cwd: context.cwd,
+  });
+}
+
+async function refreshFocusedWorkspace(): Promise<void> {
+  const workspaceId = parseWorkspaceFocusedEvent(
+    requiredEnv("HERDR_PLUGIN_EVENT_JSON")
+  );
+  const target = await loadWorkspaceTarget(workspaceId);
+  if (!target) return;
+
+  try {
+    await refreshPullRequestStatus(target);
+    await watchPullRequestStatus(target);
+  } catch {
+    // Spaces without a linked pull request do not need a watcher.
+  }
+}
+
+async function openPullRequest(): Promise<void> {
+  const context = parsePluginContext(
+    requiredEnv("HERDR_PLUGIN_CONTEXT_JSON"),
+    "pr"
+  );
+  const pullRequest = await loadPullRequestDetails(context.cwd);
+
+  await run(
+    ["gh", "pr", "view", String(pullRequest.number), "--web"],
+    { cwd: context.cwd }
+  );
+}
+
 async function runUi(): Promise<void> {
   const context = decodeLaunchContext(requiredEnv("WT_HERDR_CONTEXT"));
 
@@ -562,8 +968,26 @@ async function main(): Promise<void> {
     await openAll();
     return;
   }
+  if (command === "watch-event") {
+    await watchEvent();
+    return;
+  }
+  if (command === "watch-context") {
+    await watchContext();
+    return;
+  }
+  if (command === "refresh-focused") {
+    await refreshFocusedWorkspace();
+    return;
+  }
+  if (command === "open-pr") {
+    await openPullRequest();
+    return;
+  }
 
-  throw new Error("Usage: wt-herdr launch <new|checkout|pr> | ui | open-all");
+  throw new Error(
+    "Usage: wt-herdr launch <new|checkout|pr> | ui | open-all | watch-event | watch-context | refresh-focused | open-pr"
+  );
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
## Summary
- show compact PR and CI status tokens in Herdr Space rows
- use adaptive GitHub checks watching with focus refresh and a stable-state safety refresh
- add actions to watch existing Spaces and open the selected pull request in a browser
- document sidebar configuration and add a release changeset

## Verification
- bun test src/herdr-plugin/index.test.ts
- bun run typecheck
- bun run build:herdr-plugin
- bun test