### PR TITLE
fix: install dependencies before Herdr plugin build

### DIFF
--- a/.changeset/fix-herdr-plugin-clean-install.md
+++ b/.changeset/fix-herdr-plugin-clean-install.md
@@ -1,0 +1,5 @@
+---
+"@leesangb/wt": patch
+---
+
+Install dependencies before building the Herdr plugin from a clean GitHub checkout.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -6,6 +6,9 @@ description = "Manage wt worktrees in Herdr with live GitHub pull request and CI
 platforms = ["linux", "macos"]
 
 [[build]]
+command = ["bun", "install", "--frozen-lockfile"]
+
+[[build]]
 command = ["bun", "run", "build:herdr-plugin"]
 
 [[actions]]


### PR DESCRIPTION
## Summary
- install Bun dependencies before compiling the Herdr plugin
- keep the install reproducible with the frozen lockfile
- add a patch changeset

## Verification
- clean checkout: bun install --frozen-lockfile
- clean checkout: bun run build:herdr-plugin
- bun run typecheck
- bun test
- bunx changeset status