### PR TITLE
fix: support non-interactive Herdr installs

### DIFF
--- a/.changeset/fix-herdr-noninteractive-install.md
+++ b/.changeset/fix-herdr-noninteractive-install.md
@@ -1,0 +1,5 @@
+---
+"@leesangb/wt": patch
+---
+
+Allow `wt herdr install` to install the remote plugin from non-interactive environments.

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -584,7 +584,7 @@ describe("cli e2e", () => {
 
     assertProcessSuccess(result.status, result.stderr, result.stdout);
     expect(readFileSync(logPath, "utf-8")).toBe(
-      "plugin install leesangb/wt\n"
+      "plugin install leesangb/wt --yes\n"
     );
     expect(result.stdout).toContain("Plugin installed");
     expect(result.stdout).toContain("Installed wt for Herdr");

--- a/src/infra/herdr/client.ts
+++ b/src/infra/herdr/client.ts
@@ -73,7 +73,7 @@ export async function installHerdrPlugin(
 ): Promise<InstallHerdrPluginResult> {
   try {
     const herdr = env.HERDR_BIN_PATH ?? "herdr";
-    const proc = spawn([herdr, "plugin", "install", repository], {
+    const proc = spawn([herdr, "plugin", "install", repository, "--yes"], {
       env,
       stdout: "inherit",
       stderr: "inherit",


### PR DESCRIPTION
## Summary

- pass `--yes` when `wt herdr install` delegates to Herdr
- cover the non-interactive install contract in the CLI end-to-end test
- add a patch changeset

## Why

Herdr 0.7.4 rejects remote plugin installs when stdin is non-interactive unless `--yes` is supplied, causing `wt herdr install` to fail in automation and agent terminals.

## Verification

- `bun test` (247 passed)
- `bun run typecheck`
- `git diff --check`