### PR TITLE
Label Herdr PR worktrees with author and title

### DIFF
--- a/src/app/use-cases/create-pr-worktree.ts
+++ b/src/app/use-cases/create-pr-worktree.ts
@@ -9,10 +9,13 @@ import {
   getPullRequestInfo,
   type PullRequestInfo,
 } from "../../infra/github/cli.js";
+import { loadSettings } from "../../infra/storage/settings-store.js";
 import { AppError } from "../errors.js";
 
 export interface CreatePrWorktreeResult extends CreateWorktreeResult {
-  pullRequest: Pick<PullRequestInfo, "author" | "title">;
+  pullRequest: Pick<PullRequestInfo, "author" | "title"> & {
+    issuePattern?: string;
+  };
 }
 
 function normalizePullRequestNumber(pullRequestNumber: string): string {
@@ -32,12 +35,18 @@ export async function createPrWorktree(
   const prNumber = normalizePullRequestNumber(pullRequestNumber);
   const context = await requireRepositoryContext(cwd);
   await ensureGithubCliReady(context.repoRoot);
-  const pullRequest = await getPullRequestInfo(context.repoRoot, prNumber);
+  const [pullRequest, settings, worktrees] = await Promise.all([
+    getPullRequestInfo(context.repoRoot, prNumber),
+    loadSettings(context.repoRoot),
+    loadWorktreeInfos(context),
+  ]);
   const pullRequestSummary = {
     author: pullRequest.author,
     title: pullRequest.title,
+    ...(settings.issue?.pattern
+      ? { issuePattern: settings.issue.pattern }
+      : {}),
   };
-  const worktrees = await loadWorktreeInfos(context);
   const existingWorktree = worktrees.find(
     (worktree) => worktree.branch === pullRequest.headRefName
   );

--- a/src/app/use-cases/create-pr-worktree.ts
+++ b/src/app/use-cases/create-pr-worktree.ts
@@ -7,8 +7,13 @@ import { loadWorktreeInfos } from "../worktree-catalog.js";
 import {
   ensureGithubCliReady,
   getPullRequestInfo,
+  type PullRequestInfo,
 } from "../../infra/github/cli.js";
 import { AppError } from "../errors.js";
+
+export interface CreatePrWorktreeResult extends CreateWorktreeResult {
+  pullRequest: Pick<PullRequestInfo, "author" | "title">;
+}
 
 function normalizePullRequestNumber(pullRequestNumber: string): string {
   const value = pullRequestNumber.trim();
@@ -23,11 +28,15 @@ function normalizePullRequestNumber(pullRequestNumber: string): string {
 export async function createPrWorktree(
   pullRequestNumber: string,
   cwd: string = process.cwd()
-): Promise<CreateWorktreeResult> {
+): Promise<CreatePrWorktreeResult> {
   const prNumber = normalizePullRequestNumber(pullRequestNumber);
   const context = await requireRepositoryContext(cwd);
   await ensureGithubCliReady(context.repoRoot);
   const pullRequest = await getPullRequestInfo(context.repoRoot, prNumber);
+  const pullRequestSummary = {
+    author: pullRequest.author,
+    title: pullRequest.title,
+  };
   const worktrees = await loadWorktreeInfos(context);
   const existingWorktree = worktrees.find(
     (worktree) => worktree.branch === pullRequest.headRefName
@@ -42,13 +51,16 @@ export async function createPrWorktree(
       baseBranch: existingWorktree.baseBranch ?? "",
       baseCommit: existingWorktree.baseCommit ?? "",
       reusedExisting: true,
+      pullRequest: pullRequestSummary,
     };
   }
 
-  return createPreparedWorktree({
+  const worktree = await createPreparedWorktree({
     kind: "pull-request",
     context,
     pullRequest,
     existingIds: worktrees.map((worktree) => worktree.id),
   });
+
+  return { ...worktree, pullRequest: pullRequestSummary };
 }

--- a/src/app/use-cases/open-worktree-in-herdr.ts
+++ b/src/app/use-cases/open-worktree-in-herdr.ts
@@ -6,7 +6,9 @@ import {
 
 export async function openCreatedWorktreeInHerdr(
   worktree: Pick<CreateWorktreeResult, "id" | "worktreePath">,
-  options: { focus?: boolean } = {}
+  options: { focus?: boolean; label?: string } = {}
 ): Promise<OpenHerdrWorktreeResult> {
-  return openHerdrWorktree(worktree.worktreePath, worktree.id, options);
+  const { label = worktree.id, ...herdrOptions } = options;
+
+  return openHerdrWorktree(worktree.worktreePath, label, herdrOptions);
 }

--- a/src/app/worktree-creation.test.ts
+++ b/src/app/worktree-creation.test.ts
@@ -227,10 +227,12 @@ describe("worktree creation", () => {
         kind: "pull-request",
         context: repositoryContext,
         pullRequest: {
+          author: "octocat",
           baseRefName: "main",
           headRefName: "feature/pr",
           headRefOid: "head-commit",
           number: "17",
+          title: "Fix checkout",
           url: "https://example.test/pull/17",
         },
         existingIds: [],

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -43,6 +43,8 @@ interface CliRunOptions {
 
 interface FakeGithubCliOptions {
   authenticated?: boolean;
+  authorLogin?: string;
+  authorName?: string;
   available?: boolean;
   baseBranch?: string;
   checkoutCreatesBranchBeforeFail?: boolean;
@@ -52,6 +54,7 @@ interface FakeGithubCliOptions {
   headRefOid?: string;
   logPath?: string;
   prNumber?: string;
+  prTitle?: string;
   prUrl?: string;
 }
 
@@ -277,6 +280,8 @@ function createFakeGithubEnv(
   const binDir = join(tempDir, "bin");
   const ghPath = join(binDir, "gh");
   const baseBranch = options.baseBranch ?? "main";
+  const authorLogin = options.authorLogin ?? "sangbin";
+  const authorName = options.authorName ?? "Sangbin Lee";
   const checkoutCreatesBranchBeforeFail =
     options.checkoutCreatesBranchBeforeFail === true;
   const checkoutFailureMessage = options.checkoutFailureMessage ?? "";
@@ -285,6 +290,7 @@ function createFakeGithubEnv(
   const headRefOid =
     options.headRefOid ?? "0000000000000000000000000000000000000000";
   const prNumber = options.prNumber ?? "123";
+  const prTitle = options.prTitle ?? "Fix login: failure";
   const prUrl =
     options.prUrl ?? `https://github.com/example/repo/pull/${prNumber}`;
 
@@ -330,14 +336,14 @@ function createFakeGithubEnv(
         "    exit 0",
         "  fi",
         `  if [ "$selector" = "${prNumber}" ]; then`,
-        `    printf '%s\\n' '{"author":{"login":"sangbin"},"baseRefName":"${baseBranch}","headRefName":"${headBranch}","headRefOid":"${headRefOid}","number":${prNumber},"title":"Fix login: failure","url":"${prUrl}"}'`,
+        `    printf '%s\\n' '{"author":{"login":"${authorLogin}","name":"${authorName}"},"baseRefName":"${baseBranch}","headRefName":"${headBranch}","headRefOid":"${headRefOid}","number":${prNumber},"title":"${prTitle}","url":"${prUrl}"}'`,
         "    exit 0",
         "  fi",
         '  echo "no pull request found" >&2',
         "  exit 1",
         "fi",
         'if [ "$1" = "pr" ] && [ "${2:-}" = "list" ]; then',
-        `  printf '%s\\n' '[{"number":${prNumber},"url":"${prUrl}","title":"Fix login: failure","author":{"login":"sangbin"},"headRefName":"${headBranch}","isDraft":true}]'`,
+        `  printf '%s\\n' '[{"number":${prNumber},"url":"${prUrl}","title":"${prTitle}","author":{"login":"${authorLogin}"},"headRefName":"${headBranch}","isDraft":true}]'`,
         "  exit 0",
         "fi",
         'if [ "$1" = "pr" ] && [ "${2:-}" = "checkout" ]; then',
@@ -1210,6 +1216,12 @@ describe("cli e2e", () => {
   test("uses the PR author and title as the Herdr label", async () => {
     const repo = await createTestRepo();
     const headBranch = "feature/herdr-pr-label";
+    updateSettings(repo.repoRoot, (settings) => {
+      settings.issue = {
+        pattern: "[A-Z]+-\\d+",
+        url: "https://issues.example/$issue",
+      };
+    });
     const fakeDir = makeTempDir("wt-herdr-pr-");
     const fakeHerdr = join(fakeDir, "herdr");
     const logPath = join(fakeDir, "args.log");
@@ -1226,7 +1238,11 @@ describe("cli e2e", () => {
 
     const result = runCliCapture(["pr", "123", "--no-cd"], repo.repoRoot, {
       env: {
-        ...createFakeGithubEnv({ headBranch }),
+        ...createFakeGithubEnv({
+          headBranch,
+          prTitle:
+            "feat: MIRI-123 refactor(survey)!: survey 도메인 src/v2 이전",
+        }),
         HERDR_BIN_PATH: fakeHerdr,
         HERDR_ENV: "1",
         HERDR_WORKSPACE_ID: "w1",
@@ -1235,7 +1251,7 @@ describe("cli e2e", () => {
 
     assertProcessSuccess(result.status, result.stderr, result.stdout);
     expect(readFileSync(logPath, "utf8")).toBe(
-      `worktree open --workspace w1 --path ${getWorktreePath(repo, "pr-123")} --label sangbin: Fix login: failure --no-focus --json\n`
+      `worktree open --workspace w1 --path ${getWorktreePath(repo, "pr-123")} --label Sangbin Lee: survey 도메인 src/v2 이전 --no-focus --json\n`
     );
   });
 

--- a/src/cli.e2e.test.ts
+++ b/src/cli.e2e.test.ts
@@ -330,7 +330,7 @@ function createFakeGithubEnv(
         "    exit 0",
         "  fi",
         `  if [ "$selector" = "${prNumber}" ]; then`,
-        `    printf '%s\\n' '{"baseRefName":"${baseBranch}","headRefName":"${headBranch}","headRefOid":"${headRefOid}","number":${prNumber},"url":"${prUrl}"}'`,
+        `    printf '%s\\n' '{"author":{"login":"sangbin"},"baseRefName":"${baseBranch}","headRefName":"${headBranch}","headRefOid":"${headRefOid}","number":${prNumber},"title":"Fix login: failure","url":"${prUrl}"}'`,
         "    exit 0",
         "  fi",
         '  echo "no pull request found" >&2',
@@ -1205,6 +1205,38 @@ describe("cli e2e", () => {
       branch: headBranch,
       reusedExisting: false,
     });
+  });
+
+  test("uses the PR author and title as the Herdr label", async () => {
+    const repo = await createTestRepo();
+    const headBranch = "feature/herdr-pr-label";
+    const fakeDir = makeTempDir("wt-herdr-pr-");
+    const fakeHerdr = join(fakeDir, "herdr");
+    const logPath = join(fakeDir, "args.log");
+    writeFileSync(
+      fakeHerdr,
+      [
+        "#!/bin/sh",
+        `printf '%s\\n' "$*" > "${logPath}"`,
+        "printf '%s\\n' '{\"result\":{}}'",
+        "",
+      ].join("\n"),
+      { mode: 0o755 }
+    );
+
+    const result = runCliCapture(["pr", "123", "--no-cd"], repo.repoRoot, {
+      env: {
+        ...createFakeGithubEnv({ headBranch }),
+        HERDR_BIN_PATH: fakeHerdr,
+        HERDR_ENV: "1",
+        HERDR_WORKSPACE_ID: "w1",
+      },
+    });
+
+    assertProcessSuccess(result.status, result.stderr, result.stdout);
+    expect(readFileSync(logPath, "utf8")).toBe(
+      `worktree open --workspace w1 --path ${getWorktreePath(repo, "pr-123")} --label sangbin: Fix login: failure --no-focus --json\n`
+    );
   });
 
   test("lists open pull requests for shell completion", async () => {

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -4,6 +4,7 @@ import { runCommand } from "../cli/command-runtime.js";
 import { emitShellCd } from "../infra/shell/cd.js";
 import { printWorktreeCommandResult } from "../cli/worktree-result.js";
 import { openCreatedWorktreeInHerdr } from "../app/use-cases/open-worktree-in-herdr.js";
+import { buildPullRequestLabel } from "../domain/pull-request-label.js";
 
 interface PrCommandOptions {
   cd?: boolean;
@@ -18,7 +19,11 @@ export async function prCommand(
     const result = await createPrWorktree(pullRequestNumber);
     const herdr = await openCreatedWorktreeInHerdr(result, {
       focus: options.cd !== false,
-      label: `${result.pullRequest.author}: ${result.pullRequest.title}`,
+      label: buildPullRequestLabel(
+        result.pullRequest.author,
+        result.pullRequest.title,
+        result.pullRequest.issuePattern
+      ),
     });
 
     if (herdr.error) {

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -18,6 +18,7 @@ export async function prCommand(
     const result = await createPrWorktree(pullRequestNumber);
     const herdr = await openCreatedWorktreeInHerdr(result, {
       focus: options.cd !== false,
+      label: `${result.pullRequest.author}: ${result.pullRequest.title}`,
     });
 
     if (herdr.error) {

--- a/src/domain/pull-request-label.test.ts
+++ b/src/domain/pull-request-label.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { buildPullRequestLabel } from "./pull-request-label.js";
+
+describe("buildPullRequestLabel", () => {
+  test("removes repeated conventional prefixes and a configured issue key", () => {
+    expect(
+      buildPullRequestLabel(
+        "Sangbin Lee",
+        "feat: MIRI-123 refactor(survey)!: survey 도메인 src/v2 이전",
+        "[A-Z]+-\\d+"
+      )
+    ).toBe("Sangbin Lee: survey 도메인 src/v2 이전");
+  });
+
+  test("preserves issue keys and conventional words inside the title", () => {
+    expect(
+      buildPullRequestLabel(
+        "Sangbin Lee",
+        "Document the feat: behavior for MIRI-123",
+        "[A-Z]+-\\d+"
+      )
+    ).toBe("Sangbin Lee: Document the feat: behavior for MIRI-123");
+  });
+
+  test("keeps the original title when trimming would make it empty", () => {
+    expect(buildPullRequestLabel("Sangbin Lee", "feat: refactor:")).toBe(
+      "Sangbin Lee: feat: refactor:"
+    );
+  });
+
+  test("ignores an invalid issue pattern", () => {
+    expect(buildPullRequestLabel("Sangbin Lee", "MIRI-123: Fix survey", "[")).toBe(
+      "Sangbin Lee: MIRI-123: Fix survey"
+    );
+  });
+});

--- a/src/domain/pull-request-label.ts
+++ b/src/domain/pull-request-label.ts
@@ -1,0 +1,63 @@
+const CONVENTIONAL_PREFIX =
+  /^(?:build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(?:\([^)]*\))?!?:\s*/i;
+
+function compileIssuePattern(pattern: string | undefined): RegExp | undefined {
+  if (!pattern) {
+    return undefined;
+  }
+
+  try {
+    return new RegExp(pattern);
+  } catch {
+    return undefined;
+  }
+}
+
+function stripLeadingIssue(
+  title: string,
+  issuePattern: RegExp | undefined
+): string | undefined {
+  if (!issuePattern) {
+    return undefined;
+  }
+
+  const match = issuePattern.exec(title);
+
+  if (!match?.[0] || match.index !== 0) {
+    return undefined;
+  }
+
+  return title.slice(match[0].length).replace(/^[\s:–—-]+/, "");
+}
+
+export function buildPullRequestLabel(
+  author: string,
+  title: string,
+  issuePattern?: string
+): string {
+  const originalTitle = title.trim();
+  const compiledIssuePattern = compileIssuePattern(issuePattern);
+  let trimmedTitle = originalTitle;
+
+  while (trimmedTitle) {
+    const withoutConventionalPrefix = trimmedTitle.replace(
+      CONVENTIONAL_PREFIX,
+      ""
+    );
+
+    if (withoutConventionalPrefix !== trimmedTitle) {
+      trimmedTitle = withoutConventionalPrefix;
+      continue;
+    }
+
+    const withoutIssue = stripLeadingIssue(trimmedTitle, compiledIssuePattern);
+
+    if (withoutIssue === undefined) {
+      break;
+    }
+
+    trimmedTitle = withoutIssue;
+  }
+
+  return `${author}: ${trimmedTitle || originalTitle}`;
+}

--- a/src/infra/github/cli.ts
+++ b/src/infra/github/cli.ts
@@ -9,10 +9,12 @@ interface GithubCommandResult {
 }
 
 export interface PullRequestInfo {
+  author: string;
   baseRefName: string;
   headRefName: string;
   headRefOid: string;
   number: string;
+  title: string;
   url: string;
 }
 
@@ -96,7 +98,7 @@ export async function getPullRequestInfo(
       "view",
       pullRequestNumber,
       "--json",
-      "baseRefName,headRefName,headRefOid,number,url",
+      "author,baseRefName,headRefName,headRefOid,number,title,url",
     ],
     repoRoot
   );
@@ -108,10 +110,12 @@ export async function getPullRequestInfo(
   }
 
   let info: Partial<{
+    author: { login?: string } | null;
     baseRefName: string;
     headRefName: string;
     headRefOid: string;
     number: number;
+    title: string;
     url: string;
   }>;
 
@@ -126,16 +130,19 @@ export async function getPullRequestInfo(
     !info.headRefName ||
     !info.headRefOid ||
     typeof info.number !== "number" ||
+    !info.title ||
     !info.url
   ) {
     throw new AppError(`Could not determine branch information for PR #${pullRequestNumber}`);
   }
 
   return {
+    author: info.author?.login ?? "unknown",
     baseRefName: info.baseRefName,
     headRefName: info.headRefName,
     headRefOid: info.headRefOid,
     number: String(info.number),
+    title: info.title,
     url: info.url,
   };
 }

--- a/src/infra/github/cli.ts
+++ b/src/infra/github/cli.ts
@@ -110,7 +110,7 @@ export async function getPullRequestInfo(
   }
 
   let info: Partial<{
-    author: { login?: string } | null;
+    author: { login?: string; name?: string } | null;
     baseRefName: string;
     headRefName: string;
     headRefOid: string;
@@ -137,7 +137,7 @@ export async function getPullRequestInfo(
   }
 
   return {
-    author: info.author?.login ?? "unknown",
+    author: info.author?.name?.trim() || info.author?.login || "unknown",
     baseRefName: info.baseRefName,
     headRefName: info.headRefName,
     headRefOid: info.headRefOid,


### PR DESCRIPTION
## Summary
- fetch PR display name and title with the existing PR details lookup
- label Herdr PR worktrees as `<display name>: <trimmed title>`, falling back to the GitHub login
- trim repeated conventional commit prefixes and leading issue keys matched by `issue.pattern`
- preserve existing labels for new and checkout commands

## Verification
- `bunx tsc --noEmit`
- `bun test src/domain/pull-request-label.test.ts`
- `bun test src/cli.e2e.test.ts -t 'prints a stable JSON result for a pull request worktree|uses the PR author and title as the Herdr label|reuses an existing pull request worktree using the PR head branch'`
- `bun test src/app/worktree-creation.test.ts src/domain/pull-request-label.test.ts src/infra/herdr/client.test.ts`